### PR TITLE
Finalize Supabase data provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ My vision is to offer a reliable, free platform for managing personal finances t
 
 - Built with **React & Vite**
 - Styled with **TailwindCSS**
-- Powered by **[Evolu](https://github.com/evoluhq/evolu)**
+- Data stored via **[Supabase](https://supabase.com/)**
 - PWA (Progressive Web App) features for offline support
 
 ##  **Features**
@@ -60,6 +60,17 @@ My vision is to offer a reliable, free platform for managing personal finances t
 - [ ] **Investment Tracking**: Track your investments and monitor their performance.
 - [ ] **Net Worth Tracking**: Monitor your net worth over time.
 - [ ] **Financial Goals**: Set financial goals and track your progress.
+
+## Environment configuration
+
+Create a `.env.local` file in the project root to provide the Supabase credentials used by the application:
+
+```bash
+VITE_SUPABASE_URL=<your-supabase-project-url>
+VITE_SUPABASE_ANON_KEY=<your-supabase-anon-key>
+```
+
+Restart the development server after updating these values.
 
 ## Socials
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
 	},
 	"dependencies": {
 		"@effect/schema": "^0.72.3",
-		"@evolu/react": "^8.2.0",
 		"@fontsource-variable/inter": "^5.1.0",
 		"@fontsource-variable/roboto-mono": "^5.1.0",
 		"@hookform/resolvers": "^3.9.0",
@@ -60,9 +59,9 @@
 		"tailwindcss-animate": "^1.0.7",
 		"tailwindcss-displaymodes": "^1.0.8",
 		"unplugin-fonts": "^1.1.1",
-		"vaul": "^1.0.0",
-		"workbox-window": "^7.1.0",
-		"zod": "^3.23.8"
+                "vaul": "^1.0.0",
+                "workbox-window": "^7.1.0",
+                "zod": "^3.23.8"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.2",

--- a/src/components/custom/entry-edit-dialog.tsx
+++ b/src/components/custom/entry-edit-dialog.tsx
@@ -32,15 +32,9 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@/components/ui/select";
-import {
-	type TPopulatedEntry,
-	deleteEntry,
-	editEntry,
-	groupsQuery,
-	tagsQuery,
-} from "@/evolu-queries";
+import { useEntryActions, useGroups, useTags } from "@/contexts/data";
+import type { TPopulatedEntry } from "@/evolu-queries";
 import { cn } from "@/lib/utils";
-import { useQuery } from "@evolu/react";
 import dayjs from "dayjs";
 import { forwardRef, useEffect, useImperativeHandle, useState } from "react";
 
@@ -50,11 +44,12 @@ export interface EntryEditDialogRef {
 }
 
 export const EntryEditDialog = forwardRef<EntryEditDialogRef, {}>((_, ref) => {
-	const [entry, setEntry] = useState<TPopulatedEntry>();
-	const groups = useQuery(groupsQuery);
-	const tags = useQuery(tagsQuery);
-	const tagsCount = tags.rows.length;
-	const groupsCount = groups.rows.length;
+        const [entry, setEntry] = useState<TPopulatedEntry>();
+        const groups = useGroups();
+        const tags = useTags();
+        const tagsCount = tags.length;
+        const groupsCount = groups.length;
+        const { deleteEntry, editEntry } = useEntryActions();
 
 	const [oName, setOName] = useState<string>(entry?.details.name || "");
 	const [oAmount, setOAmount] = useState<string>(entry?.details.amount || "");
@@ -148,7 +143,7 @@ export const EntryEditDialog = forwardRef<EntryEditDialogRef, {}>((_, ref) => {
 									</SelectTrigger>
 									<SelectContent>
 										<SelectItem value="no-group">Group</SelectItem>
-										{groups.rows.map((group) => (
+                                                                                {groups.map((group) => (
 											<SelectItem key={group.id} value={group.id}>
 												{group.name}
 											</SelectItem>
@@ -172,7 +167,7 @@ export const EntryEditDialog = forwardRef<EntryEditDialogRef, {}>((_, ref) => {
 									</SelectTrigger>
 									<SelectContent>
 										<SelectItem value="no-tag">Tag</SelectItem>
-										{tags.rows.map((tag) => (
+                                                                                {tags.map((tag) => (
 											<SelectItem key={tag.id} value={tag.id}>
 												<Tag
 													className="ml-0"
@@ -208,22 +203,21 @@ export const EntryEditDialog = forwardRef<EntryEditDialogRef, {}>((_, ref) => {
 					</div>
 
 					<div className="flex items-center gap-4 mt-4">
-						<Button
-							size="sm"
-							variant="default"
-							onClick={async () => {
-								await editEntry(
-									entry,
-									oName,
-									oAmount,
-									oGroup ? oGroup : null,
-									oTag ? oTag : null,
-									() => {},
-									applyToSubsequents,
-								);
-								setOpen(false);
-							}}
-						>
+                                                <Button
+                                                        size="sm"
+                                                        variant="default"
+                                                        onClick={async () => {
+                                                                await editEntry({
+                                                                        entry,
+                                                                        newName: oName,
+                                                                        newAmount: oAmount,
+                                                                        newGroup: oGroup ? oGroup : null,
+                                                                        newTag: oTag ? oTag : null,
+                                                                        applyToSubsequents,
+                                                                });
+                                                                setOpen(false);
+                                                        }}
+                                                >
 							{m.Save()}
 						</Button>
 
@@ -256,9 +250,8 @@ export const EntryEditDialog = forwardRef<EntryEditDialogRef, {}>((_, ref) => {
 									<DropdownMenuItem
 										onSelect={async () => {
 											setTimeout(() => {
-												deleteEntry(entry, false, () => {
-													setOpen(false);
-												});
+                                                                                void deleteEntry(entry, false);
+                                                                                setOpen(false);
 											}, 100);
 										}}
 									>
@@ -269,9 +262,8 @@ export const EntryEditDialog = forwardRef<EntryEditDialogRef, {}>((_, ref) => {
 										<DropdownMenuItem
 											onSelect={async () => {
 												setTimeout(() => {
-													deleteEntry(entry, true, () => {
-														setOpen(false);
-													});
+                                                                                void deleteEntry(entry, true);
+                                                                                setOpen(false);
 												}, 100);
 											}}
 										>

--- a/src/components/custom/entry-row.tsx
+++ b/src/components/custom/entry-row.tsx
@@ -10,11 +10,8 @@ import {
 	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import {
-	type TPopulatedEntry,
-	deleteEntry,
-	toggleFullfilled,
-} from "@/evolu-queries";
+import { useEntryActions } from "@/contexts/data";
+import type { TPopulatedEntry } from "@/evolu-queries";
 import { useLocalization } from "@/hooks/use-localization";
 import { cn } from "@/lib/utils";
 import {
@@ -30,14 +27,15 @@ import type React from "react";
 import { useId } from "react";
 
 export function EntryRow({
-	entry,
-	editDialogRef,
+        entry,
+        editDialogRef,
 }: {
-	entry: TPopulatedEntry;
-	editDialogRef: React.MutableRefObject<EntryEditDialogRef | null>;
-	long?: boolean;
+        entry: TPopulatedEntry;
+        editDialogRef: React.MutableRefObject<EntryEditDialogRef | null>;
+        long?: boolean;
 }): React.ReactElement {
-	const { m, lang } = useLocalization();
+        const { m, lang } = useLocalization();
+        const { toggleEntryFullfilled, deleteEntry } = useEntryActions();
 
 	const rowId = useId();
 
@@ -55,7 +53,7 @@ export function EntryRow({
 					whileTap={{ scale: 0.97 }}
 					onClick={(e) => {
 						e.stopPropagation();
-						toggleFullfilled(entry);
+                                                void toggleEntryFullfilled(entry);
 					}}
 					className="border-r cursor-pointer border-zinc-100 dark:border-zinc-900 p-3 pl-3"
 				>
@@ -138,7 +136,7 @@ export function EntryRow({
 							<DropdownMenuItem
 								onSelect={async () => {
 									setTimeout(() => {
-										deleteEntry(entry, false, () => {});
+                                                                                void deleteEntry(entry, false);
 									}, 100);
 								}}
 							>
@@ -149,7 +147,7 @@ export function EntryRow({
 								<DropdownMenuItem
 									onSelect={async () => {
 										setTimeout(() => {
-											deleteEntry(entry, true, () => {});
+                                                                                    void deleteEntry(entry, true);
 										}, 100);
 									}}
 								>

--- a/src/components/custom/filters.tsx
+++ b/src/components/custom/filters.tsx
@@ -13,17 +13,16 @@ import {
 	PopoverContent,
 	PopoverTrigger,
 } from "@/components/ui/popover";
-import { groupsQuery, tagsQuery } from "@/evolu-queries";
+import { useGroups, useTags } from "@/contexts/data";
 import { useFilters } from "@/hooks/use-filters";
 import { useLocalization } from "@/hooks/use-localization";
 import { cn } from "@/lib/utils";
-import { useQuery } from "@evolu/react";
 import { IconCheck } from "@tabler/icons-react";
 
 export function Filters() {
-	const groups = useQuery(groupsQuery).rows;
-	const tags = useQuery(tagsQuery).rows;
-	const { m } = useLocalization();
+        const groups = useGroups();
+        const tags = useTags();
+        const { m } = useLocalization();
 
 	const { activeFilters: values, add, remove, clear } = useFilters();
 

--- a/src/components/custom/group-drawer.tsx
+++ b/src/components/custom/group-drawer.tsx
@@ -1,10 +1,9 @@
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Sheet, SheetContent } from "@/components/ui/sheet";
-import { type TEvoluDB, decodeName } from "@/evolu-db";
-import { deleteGroup, groupsQuery } from "@/evolu-queries";
+import { decodeName } from "@/evolu-db";
+import { useData } from "@/contexts/data";
 import { useLocalization } from "@/hooks/use-localization";
-import { useEvolu, useQuery } from "@evolu/react";
 import { IconFolderOpen, IconPlus, IconTrash } from "@tabler/icons-react";
 import React, { forwardRef, useImperativeHandle } from "react";
 
@@ -17,11 +16,10 @@ export interface GroupDrawerRef {
 
 export const GroupDrawer = forwardRef<GroupDrawerRef, GroupDrawerProps>(
 	(_, ref) => {
-		const { m } = useLocalization();
-		const { create } = useEvolu<TEvoluDB>();
-		const groups = useQuery(groupsQuery);
-		const [open, setOpen] = React.useState(false);
-		const [newGroupName, setNewGroupName] = React.useState<string>("");
+                const { m } = useLocalization();
+                const { groups, createGroup, deleteGroup } = useData();
+                const [open, setOpen] = React.useState(false);
+                const [newGroupName, setNewGroupName] = React.useState<string>("");
 
 		useImperativeHandle(ref, () => ({
 			openDrawer: () => {
@@ -50,12 +48,12 @@ export const GroupDrawer = forwardRef<GroupDrawerRef, GroupDrawerProps>(
 								{m.Groups()}
 							</div>
 
-							{groups.rows.length === 0 && (
-								<div className="pb-6 py-4 flex flex-col gap-2 text-muted-foreground text-center text-balance mt-4">
-									<IconFolderOpen className="size-12 stroke-1 mx-auto mb-3 text-zinc-400 dark:text-zinc-600" />
-									{m.GroupsEmptyDesc()}
-								</div>
-							)}
+                                                        {groups.length === 0 && (
+                                                                <div className="pb-6 py-4 flex flex-col gap-2 text-muted-foreground text-center text-balance mt-4">
+                                                                        <IconFolderOpen className="size-12 stroke-1 mx-auto mb-3 text-zinc-400 dark:text-zinc-600" />
+                                                                        {m.GroupsEmptyDesc()}
+                                                                </div>
+                                                        )}
 							<div className="flex items-center gap-2 mb-4">
 								<Input
 									value={newGroupName}
@@ -67,30 +65,29 @@ export const GroupDrawer = forwardRef<GroupDrawerRef, GroupDrawerProps>(
 									size="icon"
 									className="shrink-0"
 									onClick={() => {
-										create("entryGroup", {
-											name: decodeName(newGroupName),
-										});
-										setNewGroupName("");
-									}}
-								>
+                                                                                const parsedName = decodeName(newGroupName);
+                                                                                void createGroup(parsedName);
+                                                                                setNewGroupName("");
+                                                                        }}
+                                                                >
 									<IconPlus className="size-5" />
 								</Button>
 							</div>
-							{groups.rows.length > 0 && (
-								<div className="grid grid-cols-1 gap-0.5 mt-4">
-									{groups.rows.map((group) => (
-										<div
-											key={group.id}
-											className="flex items-center justify-between p-3 py-2 pl-5 rounded bg-zinc-100 dark:bg-zinc-900"
-										>
-											<div className="text-base font-medium">{group.name}</div>
-											<Button
-												size="icon"
-												variant="outline"
-												onClick={() => {
-													deleteGroup(group.id);
-												}}
-											>
+                                                        {groups.length > 0 && (
+                                                                <div className="grid grid-cols-1 gap-0.5 mt-4">
+                                                                        {groups.map((group) => (
+                                                                                <div
+                                                                                        key={group.id}
+                                                                                        className="flex items-center justify-between p-3 py-2 pl-5 rounded bg-zinc-100 dark:bg-zinc-900"
+                                                                                >
+                                                                                        <div className="text-base font-medium">{group.name}</div>
+                                                                                        <Button
+                                                                                                size="icon"
+                                                                                                variant="outline"
+                                                                                                onClick={() => {
+                                                                                                        void deleteGroup(group.id);
+                                                                                                }}
+                                                                                        >
 												<IconTrash className="size-5" />
 											</Button>
 										</div>

--- a/src/components/custom/tag-drawer.tsx
+++ b/src/components/custom/tag-drawer.tsx
@@ -6,10 +6,9 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Sheet, SheetContent } from "@/components/ui/sheet";
-import { type TEvoluDB, decodeName } from "@/evolu-db";
-import { deleteTag, tagsQuery } from "@/evolu-queries";
+import { decodeName } from "@/evolu-db";
+import { useData } from "@/contexts/data";
 import { useLocalization } from "@/hooks/use-localization";
-import { useEvolu, useQuery } from "@evolu/react";
 import { IconPlus, IconTags, IconTrash } from "@tabler/icons-react";
 import React, { forwardRef, useImperativeHandle } from "react";
 
@@ -21,9 +20,8 @@ export interface TagDrawerRef {
 }
 
 export const TagDrawer = forwardRef<TagDrawerRef, TagDrawerProps>((_, ref) => {
-	const { create, update } = useEvolu<TEvoluDB>();
-	const tags = useQuery(tagsQuery);
-	const [open, setOpen] = React.useState(false);
+        const { tags, createTag, updateTagColor, deleteTag } = useData();
+        const [open, setOpen] = React.useState(false);
 	const [newTagName, setNewTagName] = React.useState<string>("");
 	const [newTagColor, setNewTagColor] = React.useState<string>("zinc");
 	const { m } = useLocalization();
@@ -45,10 +43,9 @@ export const TagDrawer = forwardRef<TagDrawerRef, TagDrawerProps>((_, ref) => {
 		{ suggestId: "bill", name: m.Bill(), color: "blue" },
 	];
 
-	const availableSuggestedTags = suggestedTags.filter(
-		(suggestedTag) =>
-			!tags.rows.some((tag) => tag.suggestId === suggestedTag.suggestId),
-	);
+        const availableSuggestedTags = suggestedTags.filter(
+                (suggestedTag) => !tags.some((tag) => tag.suggestId === suggestedTag.suggestId),
+        );
 
 	return (
 		<>
@@ -67,7 +64,7 @@ export const TagDrawer = forwardRef<TagDrawerRef, TagDrawerProps>((_, ref) => {
 						<div className="text-lg text-left flex justify-between items-center capitalize font-medium leading-none tracking-tight h-11">
 							{m.Tags()}
 						</div>
-						{tags.rows.length === 0 && (
+                                                {tags.length === 0 && (
 							<div className="pb-6 py-4 flex flex-col gap-2 text-muted-foreground text-center text-balance mt-4">
 								<IconTags className="size-12 mb-3 mx-auto stroke-1 text-zinc-400 dark:text-zinc-600" />
 								{m.TagsEmptyDesc()}
@@ -90,25 +87,26 @@ export const TagDrawer = forwardRef<TagDrawerRef, TagDrawerProps>((_, ref) => {
 									className="rounded-l-none"
 								/>
 							</div>
-							<Button
-								variant="default"
-								size="icon"
-								className="shrink-0"
-								onClick={() => {
-									create("entryTag", {
-										name: decodeName(newTagName),
-										color: newTagColor,
-									});
-									setNewTagColor("zinc");
-									setNewTagName("");
-								}}
-							>
+                                                        <Button
+                                                                variant="default"
+                                                                size="icon"
+                                                                className="shrink-0"
+                                                                onClick={() => {
+                                                                        const parsedName = decodeName(newTagName);
+                                                                        void createTag({
+                                                                                name: parsedName,
+                                                                                color: newTagColor,
+                                                                        });
+                                                                        setNewTagColor("zinc");
+                                                                        setNewTagName("");
+                                                                }}
+                                                        >
 								<IconPlus className="size-5" />
 							</Button>
 						</div>
-						{tags.rows.length > 0 && (
-							<div className="grid grid-cols-1 gap-0.5 mt-4">
-								{tags.rows.map((tag) => (
+                                                {tags.length > 0 && (
+                                                        <div className="grid grid-cols-1 gap-0.5 mt-4">
+                                                                {tags.map((tag) => (
 									<div
 										key={tag.id}
 										className="flex items-center justify-between p-3 py-2 rounded bg-zinc-100 dark:bg-zinc-900"
@@ -118,9 +116,9 @@ export const TagDrawer = forwardRef<TagDrawerRef, TagDrawerProps>((_, ref) => {
 												className="text-base font-medium"
 												dotClassName="size-4 mr-1"
 												allowColorChange
-												onColorChange={(color) => {
-													update("entryTag", { id: tag.id, color });
-												}}
+                                                                                                onColorChange={(color) => {
+                                                                                                        void updateTagColor(tag.id, color);
+                                                                                                }}
 												name={tag.name}
 												color={tag.color as TagColor}
 											/>
@@ -129,7 +127,7 @@ export const TagDrawer = forwardRef<TagDrawerRef, TagDrawerProps>((_, ref) => {
 											size="icon"
 											variant="outline"
 											onClick={() => {
-												deleteTag(tag.id);
+                                                                                                void deleteTag(tag.id);
 											}}
 										>
 											<IconTrash className="size-5" />
@@ -157,17 +155,18 @@ export const TagDrawer = forwardRef<TagDrawerRef, TagDrawerProps>((_, ref) => {
 													color={tag.color as TagColor}
 												/>
 											</div>
-											<Button
-												size="icon"
-												variant="outline"
-												onClick={() => {
-													create("entryTag", {
-														name: decodeName(tag.name),
-														color: tag.color,
-														suggestId: tag.suggestId,
-													});
-												}}
-											>
+                                                                                        <Button
+                                                                                                size="icon"
+                                                                                                variant="outline"
+                                                                                                onClick={() => {
+                                                                                                        const parsedName = decodeName(tag.name);
+                                                                                                        void createTag({
+                                                                                                                name: parsedName,
+                                                                                                                color: tag.color,
+                                                                                                                suggestId: tag.suggestId,
+                                                                                                        });
+                                                                                                }}
+                                                                                        >
 												<IconPlus className="size-5" />
 											</Button>
 										</div>

--- a/src/components/custom/v2/add-entry/group-select.tsx
+++ b/src/components/custom/v2/add-entry/group-select.tsx
@@ -1,9 +1,8 @@
 import { Button } from "@/components/ui/button";
 import { Select, SelectContent, SelectItem } from "@/components/ui/select";
 import type { TGroupId } from "@/evolu-db";
-import { groupsQuery } from "@/evolu-queries";
+import { useGroups } from "@/contexts/data";
 import { useLocalization } from "@/hooks/use-localization";
-import { useQuery } from "@evolu/react";
 import { SelectTrigger } from "@radix-ui/react-select";
 import { IconCategory2 } from "@tabler/icons-react";
 
@@ -14,7 +13,7 @@ export function GroupSelect({
 	value: string | undefined;
 	onValueChange: (value: TGroupId) => void;
 }) {
-	const groups = useQuery(groupsQuery);
+        const groups = useGroups();
 	const { m } = useLocalization();
 	return (
 		<Select onValueChange={onValueChange} value={value || "no-group"}>
@@ -26,7 +25,7 @@ export function GroupSelect({
 				>
 					<IconCategory2 className="-left-1.5 relative text-muted-foreground size-5 shrink-0" />
 					<span className="truncate max-w-24">
-						{groups.rows.find((g) => g.id === value)?.name || (
+                                                {groups.find((g) => g.id === value)?.name || (
 							<span className="text-muted-foreground">{m.Group()}</span>
 						)}
 					</span>
@@ -34,7 +33,7 @@ export function GroupSelect({
 			</SelectTrigger>
 			<SelectContent>
 				<SelectItem value="no-group">{m.Group()}</SelectItem>
-				{groups.rows.map((group) => (
+                                {groups.map((group) => (
 					<SelectItem key={group.id} value={group.id}>
 						{group.name}
 					</SelectItem>

--- a/src/components/custom/v2/add-entry/tag-select.tsx
+++ b/src/components/custom/v2/add-entry/tag-select.tsx
@@ -3,9 +3,8 @@ import type { TagColor } from "@/components/custom/tag-color-picker";
 import { Button } from "@/components/ui/button";
 import { Select, SelectContent, SelectItem } from "@/components/ui/select";
 import type { TTagId } from "@/evolu-db";
-import { tagsQuery } from "@/evolu-queries";
+import { useTags } from "@/contexts/data";
 import { useLocalization } from "@/hooks/use-localization";
-import { useQuery } from "@evolu/react";
 import { SelectTrigger } from "@radix-ui/react-select";
 import { IconTag } from "@tabler/icons-react";
 
@@ -16,9 +15,9 @@ export function TagSelect({
 	value: string | undefined;
 	onValueChange: (value: TTagId) => void;
 }) {
-	const tags = useQuery(tagsQuery);
-	const { m } = useLocalization();
-	const selectedTag = tags.rows.find((t) => t.id === value);
+        const tags = useTags();
+        const { m } = useLocalization();
+        const selectedTag = tags.find((t) => t.id === value);
 
 	return (
 		<Select onValueChange={onValueChange} value={value || "no-tag"}>
@@ -46,7 +45,7 @@ export function TagSelect({
 			</SelectTrigger>
 			<SelectContent>
 				<SelectItem value="no-tag">{m.Tag()}</SelectItem>
-				{tags.rows.map((tag) => (
+                                {tags.map((tag) => (
 					<SelectItem key={tag.id} value={tag.id}>
 						<Tag
 							className="ml-0"

--- a/src/components/custom/v2/erase-data-drawer.tsx
+++ b/src/components/custom/v2/erase-data-drawer.tsx
@@ -8,7 +8,7 @@ import {
 	DrawerHeader,
 	DrawerTitle,
 } from "@/components/ui/drawer";
-import { evolu } from "@/evolu-db";
+import { useData } from "@/contexts/data";
 import { useLocalization } from "@/hooks/use-localization";
 import { IconTrashXFilled } from "@tabler/icons-react";
 import { forwardRef, useImperativeHandle, useState } from "react";
@@ -19,8 +19,9 @@ export interface EraseDataDrawerRef {
 }
 
 export const EraseDataDrawer = forwardRef<EraseDataDrawerRef, {}>((_, ref) => {
-	const [open, setOpen] = useState(false);
-	const { m } = useLocalization();
+        const [open, setOpen] = useState(false);
+        const { m } = useLocalization();
+        const { eraseAllData } = useData();
 
 	useImperativeHandle(ref, () => ({
 		openDrawer: () => {
@@ -43,11 +44,11 @@ export const EraseDataDrawer = forwardRef<EraseDataDrawerRef, {}>((_, ref) => {
 					<Button
 						variant="destructive"
 						size="lg"
-						onClick={async () => {
-							await evolu.resetOwner({ reload: false });
-							window.localStorage.clear();
-							window.location.reload();
-						}}
+                                                onClick={async () => {
+                                                        await eraseAllData();
+                                                        window.localStorage.clear();
+                                                        window.location.reload();
+                                                }}
 					>
 						{m.EraseAllDataAndStartOver()}
 					</Button>

--- a/src/components/custom/v2/private-key-drawer.tsx
+++ b/src/components/custom/v2/private-key-drawer.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/components/ui/drawer";
 import HyperText from "@/components/ui/hyper-text";
 import { useLocalization } from "@/hooks/use-localization";
-import { useOwner } from "@evolu/react";
+import { storageKeys } from "@/lib/utils";
 import { IconCircleKeyFilled, IconCopyCheckFilled, IconEyeFilled } from "@tabler/icons-react";
 import { motion } from "framer-motion";
 import { forwardRef, useImperativeHandle, useState } from "react";
@@ -21,11 +21,12 @@ export interface PrivateKeyDrawerRef {
 }
 
 export const PrivateKeyDrawer = forwardRef<PrivateKeyDrawerRef, {}>((_, ref) => {
-	const [open, setOpen] = useState(false);
-	const [reveal, setReveal] = useState(false);
-	const [copy, setCopy] = useState(false);
+        const [open, setOpen] = useState(false);
+        const [reveal, setReveal] = useState(false);
+        const [copy, setCopy] = useState(false);
+        const [privateKey, setPrivateKey] = useState<string>(() => localStorage.getItem(storageKeys.privateKey) ?? "");
 
-	const { m } = useLocalization();
+        const { m } = useLocalization();
 
 	function copyToClipboard(text: string) {
 		navigator.clipboard.writeText(text).then(() => {
@@ -36,20 +37,19 @@ export const PrivateKeyDrawer = forwardRef<PrivateKeyDrawerRef, {}>((_, ref) => 
 		});
 	}
 
-	useImperativeHandle(ref, () => ({
-		openDrawer: () => {
-			setOpen(true);
-		},
-		closeDrawer: () => {
-			setOpen(false);
-		},
-	}));
+        useImperativeHandle(ref, () => ({
+                openDrawer: () => {
+                        setPrivateKey(localStorage.getItem(storageKeys.privateKey) ?? "");
+                        setOpen(true);
+                },
+                closeDrawer: () => {
+                        setOpen(false);
+                },
+        }));
 
-	const owner = useOwner();
-
-	return (
-		<Drawer
-			open={open}
+        return (
+                <Drawer
+                        open={open}
 			onOpenChange={(v) => {
 				setOpen(v);
 				setReveal(false);
@@ -61,35 +61,37 @@ export const PrivateKeyDrawer = forwardRef<PrivateKeyDrawerRef, {}>((_, ref) => 
 					<DrawerTitle>{m.PrivateKey()}</DrawerTitle>
 					<DrawerDescription className="text-balance">{m.PrivateKeyDescription()}</DrawerDescription>
 				</DrawerHeader>
-				<motion.div
-					className="mx-4 border rounded bg-input border-input"
-					initial={{ height: 0, scale: 0, opacity: 0 }}
-					animate={reveal ? { height: "auto", scale: 1, opacity: 1 } : { height: 0, scale: 0, opacity: 0 }}
-				>
-					<div className="px-4 font-mono text-center">
-						<HyperText animateOnLoad={reveal} text={owner?.mnemonic || ""} />
-					</div>
-				</motion.div>
-				<DrawerFooter className="grid grid-cols-2">
-					<Button
-						variant="secondary"
-						size="lg"
-						onClick={() => {
-							setReveal((prev) => !prev);
-						}}
-					>
-						<IconEyeFilled className="mr-2" />
-						{reveal ? m.Hide() : m.Reveal()}
-					</Button>
-					<Button
-						variant="default"
-						size="lg"
-						onClick={() => {
-							copyToClipboard(owner?.mnemonic || "");
-						}}
-					>
-						<IconCopyCheckFilled className="mr-2" />
-						{copy ? m.Copied() : m.Copy()}
+                                <motion.div
+                                        className="mx-4 border rounded bg-input border-input"
+                                        initial={{ height: 0, scale: 0, opacity: 0 }}
+                                        animate={reveal ? { height: "auto", scale: 1, opacity: 1 } : { height: 0, scale: 0, opacity: 0 }}
+                                >
+                                        <div className="px-4 font-mono text-center">
+                                                <HyperText animateOnLoad={reveal} text={privateKey} />
+                                        </div>
+                                </motion.div>
+                                <DrawerFooter className="grid grid-cols-2">
+                                        <Button
+                                                variant="secondary"
+                                                size="lg"
+                                                disabled={!privateKey}
+                                                onClick={() => {
+                                                        setReveal((prev) => !prev);
+                                                }}
+                                        >
+                                                <IconEyeFilled className="mr-2" />
+                                                {reveal ? m.Hide() : m.Reveal()}
+                                        </Button>
+                                        <Button
+                                                variant="default"
+                                                size="lg"
+                                                disabled={!privateKey}
+                                                onClick={() => {
+                                                        copyToClipboard(privateKey);
+                                                }}
+                                        >
+                                                <IconCopyCheckFilled className="mr-2" />
+                                                {copy ? m.Copied() : m.Copy()}
 					</Button>
 				</DrawerFooter>
 			</DrawerContent>

--- a/src/components/custom/v2/restore-key-drawer.tsx
+++ b/src/components/custom/v2/restore-key-drawer.tsx
@@ -9,9 +9,8 @@ import {
 	DrawerTitle,
 } from "@/components/ui/drawer";
 import { useToast } from "@/components/ui/use-toast";
-import { evolu } from "@/evolu-db";
 import { useLocalization } from "@/hooks/use-localization";
-import { validateMnemonic } from "@/lib/utils";
+import { storageKeys, validateMnemonic } from "@/lib/utils";
 import { IconCloudDownload } from "@tabler/icons-react";
 import { forwardRef, useImperativeHandle, useState } from "react";
 
@@ -70,13 +69,20 @@ export const RestoreKeyDrawer = forwardRef<RestoreKeyDrawerRef, {}>((_, ref) => 
 								});
 								return;
 							}
-							setRestoring(true);
-							evolu.restoreOwner(validKey, {
-								reload: true,
-							});
-						}}
-					>
-						{restoring ? m.Restoring() : m.Restore()}
+                                                        setRestoring(true);
+                                                        localStorage.setItem(storageKeys.privateKey, validKey);
+                                                        setRestoring(false);
+                                                        setOpen(false);
+                                                        setRestoreKey("");
+                                                        toast({
+                                                                title: m.PrivateKey(),
+                                                                description: m.RestoreWithPrivateKeyDesc(),
+                                                                type: "foreground",
+                                                                duration: 3000,
+                                                        });
+                                                }}
+                                        >
+                                                {restoring ? m.Restoring() : m.Restore()}
 					</Button>
 				</DrawerFooter>
 			</DrawerContent>

--- a/src/contexts/data.ts
+++ b/src/contexts/data.ts
@@ -1,0 +1,120 @@
+import { createContext, useContext } from "react";
+
+import type {
+        TEntryRow,
+        TPopulatedEntry,
+        TRecurringConfigRow,
+        TTagRow,
+        TGroupRow,
+} from "@/evolu-queries";
+
+export interface TagInput {
+        name: string;
+        color?: string | null;
+        suggestId?: string | null;
+}
+
+export interface CreateEntryInput {
+        name: string;
+        amount: string;
+        currencyCode: string;
+        date: string;
+        type: "income" | "expense" | "assets";
+        groupId: string | null;
+        tagId: string | null;
+        fullfilled: boolean;
+        recurringId: string | null;
+}
+
+export interface CreateRecurringConfigInput {
+        frequency: "week" | "month" | "year";
+        interval: number;
+        every: number;
+        startDate: string;
+        endDate: string | null;
+}
+
+export interface MutationOptions {
+        skipRefresh?: boolean;
+}
+
+export interface EditEntryInput {
+        entry: TPopulatedEntry;
+        newName: string;
+        newAmount: string;
+        newGroup: string | null;
+        newTag: string | null;
+        applyToSubsequents?: boolean;
+        onComplete?: () => void;
+}
+
+export interface DataContextValue {
+        loading: boolean;
+        groups: TGroupRow[];
+        tags: TTagRow[];
+        entries: TEntryRow[];
+        recurringConfigs: TRecurringConfigRow[];
+        refresh: () => Promise<void>;
+        createGroup: (name: string) => Promise<void>;
+        deleteGroup: (id: string) => Promise<void>;
+        createTag: (input: TagInput) => Promise<void>;
+        updateTagColor: (id: string, color: string | null) => Promise<void>;
+        deleteTag: (id: string) => Promise<void>;
+        createEntry: (input: CreateEntryInput, options?: MutationOptions) => Promise<string | null>;
+        createRecurringConfig: (
+                input: CreateRecurringConfigInput,
+                options?: MutationOptions,
+        ) => Promise<string | null>;
+        createExclusion: (input: {
+                recurringId: string;
+                date: string;
+                reason: "deletion" | "modification";
+                modifiedEntryId: string | null;
+        }, options?: MutationOptions) => Promise<string | null>;
+        updateEntry: (
+                id: string,
+                values: Partial<
+                        Omit<CreateEntryInput, "recurringId" | "date"> & { date?: string; recurringId?: string | null }
+                >,
+                options?: MutationOptions,
+        ) => Promise<void>;
+        updateRecurringConfig: (
+                id: string,
+                values: Partial<{
+                        interval: number | null;
+                        every: number | null;
+                        endDate: string | null;
+                        isDeleted: boolean;
+                }>,
+                options?: MutationOptions,
+        ) => Promise<void>;
+        updateExclusion: (
+                id: string,
+                values: Partial<{ reason: "deletion" | "modification" | null; isDeleted: boolean }>;
+                options?: MutationOptions,
+        ) => Promise<void>;
+        toggleEntryFullfilled: (entry: TPopulatedEntry) => Promise<void>;
+        deleteEntry: (entry: TPopulatedEntry, withSubsequents?: boolean) => Promise<void>;
+        editEntry: (input: EditEntryInput) => Promise<void>;
+        eraseAllData: () => Promise<void>;
+}
+
+export const DataContext = createContext<DataContextValue | undefined>(undefined);
+
+export const useData = () => {
+        const context = useContext(DataContext);
+        if (!context) {
+                throw new Error("useData must be used within a DataProvider");
+        }
+        return context;
+};
+
+export const useGroups = () => useData().groups;
+export const useTags = () => useData().tags;
+export const useEntries = () => useData().entries;
+export const useRecurringConfigs = () => useData().recurringConfigs;
+
+export const useEntryActions = () => {
+        const { toggleEntryFullfilled, deleteEntry, editEntry } = useData();
+        return { toggleEntryFullfilled, deleteEntry, editEntry };
+};

--- a/src/evolu-db.ts
+++ b/src/evolu-db.ts
@@ -1,115 +1,35 @@
-import * as S from "@effect/schema/Schema";
-import {
-	SqliteBoolean,
-	SqliteDate,
-	String as SqliteString,
-	createEvolu,
-	createIndexes,
-	database,
-	id,
-	table,
-} from "@evolu/react";
+import { z } from "zod";
 
-export const NonEmptyString100 = SqliteString.pipe(S.minLength(1), S.maxLength(100), S.brand("NonEmptyString100"));
-export type TNonEmptyString100 = typeof NonEmptyString100.Type;
+export const NonEmptyString100 = z.string().trim().min(1).max(100);
+export type TNonEmptyString100 = z.infer<typeof NonEmptyString100>;
 
-export const CurrencyIsoString = SqliteString.pipe(S.minLength(3), S.maxLength(3), S.brand("CurrencyIsoString"));
-export type TCurrencyIsoString = typeof CurrencyIsoString.Type;
+export const CurrencyIsoString = z.string().trim().length(3);
+export type TCurrencyIsoString = z.infer<typeof CurrencyIsoString>;
 
-export const AmountString = SqliteString.pipe(S.pattern(/^\d+\.\d{8}$/), S.brand("AmountString"));
-export type TAmountString = typeof AmountString.Type;
+export const AmountString = z
+        .string()
+        .regex(/^\d+\.\d{8}$/);
+export type TAmountString = z.infer<typeof AmountString>;
 
-// Branded Ids
-const EntryId = id("Entry");
-export type TEntryId = typeof EntryId.Type;
+export type TEntryId = string;
+export type TRecurringConfigId = string;
+export type TExclusionId = string;
+export type TGroupId = string;
+export type TTagId = string;
 
-const RecurringConfigId = id("RecurringConfig");
-export type TRecurringConfigId = typeof RecurringConfigId.Type;
+const DateStringSchema = z.union([z.string(), z.date()]).transform((value) =>
+        value instanceof Date ? value.toISOString() : new Date(value).toISOString(),
+);
 
-const ExclusionId = id("Exclusion");
-export type TExclusionId = typeof ExclusionId.Type;
+const GroupIdSchema = z.string().uuid();
+const TagIdSchema = z.string().uuid();
+const RecurringConfigIdSchema = z.string().uuid();
 
-const GroupId = id("Group");
-export type TGroupId = typeof GroupId.Type;
+export const decodeName = (value: string) => NonEmptyString100.parse(value);
+export const decodeCurrency = (value: string) => CurrencyIsoString.parse(value.toUpperCase());
+export const decodeAmount = (value: string) => AmountString.parse(value);
+export const decodeDate = (value: string | Date) => DateStringSchema.parse(value);
+export const decodeGroupId = (value: string) => GroupIdSchema.parse(value);
+export const decodeTagId = (value: string) => TagIdSchema.parse(value);
+export const decodeRecurringConfigId = (value: string) => RecurringConfigIdSchema.parse(value);
 
-const TagId = id("Tag");
-export type TTagId = typeof TagId.Type;
-
-const EntryTable = table({
-	id: EntryId,
-	date: SqliteDate,
-	type: S.Union(S.Literal("income"), S.Literal("expense")),
-	name: NonEmptyString100,
-	amount: AmountString,
-	fullfilled: SqliteBoolean,
-	currencyCode: CurrencyIsoString,
-	recurringId: S.NullOr(RecurringConfigId),
-	groupId: S.NullOr(GroupId),
-	tagId: S.NullOr(TagId),
-});
-
-const GroupTable = table({
-	id: GroupId,
-	name: NonEmptyString100,
-	icon: S.NullOr(S.String),
-});
-
-const TagTable = table({
-	id: TagId,
-	name: NonEmptyString100,
-	suggestId: S.NullOr(S.String),
-	color: S.NullOr(S.String),
-	icon: S.NullOr(S.String),
-});
-
-const RecurringConfigTable = table({
-	id: RecurringConfigId,
-	frequency: S.Union(S.Literal("week"), S.Literal("month"), S.Literal("year")),
-	interval: S.Number,
-	every: S.Number,
-	startDate: SqliteDate,
-	endDate: S.NullOr(SqliteDate),
-});
-
-const ExclusionTable = table({
-	id: ExclusionId,
-	recurringId: RecurringConfigId,
-	date: SqliteDate,
-	reason: S.Union(S.Literal("deletion"), S.Literal("modification")),
-	modifiedEntryId: S.NullOr(EntryId),
-});
-
-// Now, we can define the database schema.
-export const EvoluDB = database({
-	entry: EntryTable,
-	entryGroup: GroupTable,
-	entryTag: TagTable,
-	recurringConfig: RecurringConfigTable,
-	exclusion: ExclusionTable,
-});
-
-// TODO: Add indexes
-const indexes = createIndexes((create) => [create("indexEntryByDate").on("entry").column("date")]);
-
-const decode = S.decodeSync;
-const decodeName = S.decodeSync(NonEmptyString100);
-const decodeCurrency = S.decodeSync(CurrencyIsoString);
-const decodeAmount = S.decodeSync(AmountString);
-const decodeDate = S.decodeSync(SqliteDate);
-const decodeGroupId = S.decodeSync(GroupId);
-const decodeTagId = S.decodeSync(TagId);
-
-export const evolu = createEvolu(EvoluDB, {
-	// minimumLogLevel: "trace",
-	// name: "gider.im",
-	indexes,
-	// ...(process.env.NODE_ENV === "development" && {
-	// 	syncUrl: "http://localhost:4000",
-	// }),
-	// enableWebsocketConnection: true,
-});
-
-export type TEvoluDB = typeof EvoluDB.Type;
-export type TEntryTable = typeof EntryTable.Type;
-
-export { S, decode, decodeAmount, decodeCurrency, decodeDate, decodeGroupId, decodeName, decodeTagId };

--- a/src/evolu-queries.ts
+++ b/src/evolu-queries.ts
@@ -1,1061 +1,429 @@
-import {
-	type TEntryId,
-	type TExclusionId,
-	type TGroupId,
-	type TRecurringConfigId,
-	type TTagId,
-	decodeAmount,
-	decodeName,
-	evolu,
-} from "@/evolu-db";
+import type { TGroupId, TTagId } from "@/evolu-db";
 import { storageKeys } from "@/lib/utils";
-import { type ExtractRow, type NotNull, cast, jsonArrayFrom, jsonObjectFrom } from "@evolu/react";
 import dayjs, { type Dayjs } from "dayjs";
 
-type TNarrowed = {
-	name: NotNull;
-	date: NotNull;
-	amount: NotNull;
-	fullfilled: NotNull;
-	currencyCode: NotNull;
-	type: NotNull;
+type EntryGroupInfo = {
+        groupId: string;
+        name: string;
 };
 
-const queryOptions = {
-	logQueryExecutionTime: process.env.NODE_ENV === "development",
-	logExplainQueryPlan: process.env.NODE_ENV === "development",
+type EntryTagInfo = {
+        tagId: string;
+        name: string;
+        color: string | null;
 };
 
-export const recurringConfigsQuery = evolu.createQuery(
-	(db) =>
-		db
-			.selectFrom("recurringConfig as r")
-			.select([
-				"r.id as recurringConfigId",
-				"r.frequency",
-				"r.interval",
-				"r.every",
-				"r.startDate",
-				"r.endDate",
-				"r.createdAt",
-			])
-			.where("r.isDeleted", "is not", cast(true))
-			.$narrowType<
-				TNarrowed & {
-					frequency: NotNull;
-				}
-			>()
-			.orderBy("r.createdAt")
-			.select((eb) => [
-				jsonArrayFrom(
-					eb
-						.selectFrom("exclusion")
-						.select(["id", "recurringId", "date", "reason", "modifiedEntryId"])
-						.whereRef("r.id", "=", "exclusion.recurringId")
-						.select((eb) => [
-							jsonObjectFrom(
-								eb
-									.selectFrom("entry as modifiedEntry")
-									.select([
-										"id as entryId",
-										"name",
-										"type",
-										"currencyCode",
-										"amount",
-										"date",
-										"createdAt",
-										"fullfilled",
-										"recurringId",
-										"updatedAt",
-										"groupId",
-										"tagId",
-									])
-									.select((eb) => [
-										jsonObjectFrom(
-											eb
-												.selectFrom("entryGroup")
-												.select(["id as groupId", "name"])
-												.where("entryGroup.isDeleted", "is not", cast(true))
-												.whereRef("entryGroup.id", "=", "modifiedEntry.groupId"),
-										).as("entryGroup"),
-									])
-									.select((eb) => [
-										jsonObjectFrom(
-											eb
-												.selectFrom("entryTag")
-												.select(["id as tagId", "name", "color"])
-												.where("entryTag.isDeleted", "is not", cast(true))
-												.whereRef("entryTag.id", "=", "modifiedEntry.tagId"),
-										).as("entryTag"),
-									])
-									.$narrowType<TNarrowed>()
-									.whereRef("modifiedEntry.id", "=", "exclusion.modifiedEntryId"),
-							).as("modifiedEntry"),
-						])
-						.where("exclusion.isDeleted", "is not", cast(true)),
-				).as("exclusions"),
-			])
-			.select((eb) => [
-				jsonObjectFrom(
-					eb
-						.selectFrom("entry")
-						.select([
-							"id as entryId",
-							"name",
-							"type",
-							"currencyCode",
-							"amount",
-							"date",
-							"createdAt",
-							"fullfilled",
-							"recurringId",
-							"updatedAt",
-							"groupId",
-							"tagId",
-						])
-						.select((eb) => [
-							jsonObjectFrom(
-								eb
-									.selectFrom("entryGroup")
-									.select(["id as groupId", "name"])
-									.where("entryGroup.isDeleted", "is not", cast(true))
-									.whereRef("entryGroup.id", "=", "entry.groupId"),
-							).as("entryGroup"),
-						])
-						.select((eb) => [
-							jsonObjectFrom(
-								eb
-									.selectFrom("entryTag")
-									.select(["id as tagId", "name", "color"])
-									.where("entryTag.isDeleted", "is not", cast(true))
-									.whereRef("entryTag.id", "=", "entry.tagId"),
-							).as("entryTag"),
-						])
-						.whereRef("r.id", "=", "entry.recurringId")
-						.where("entry.isDeleted", "is not", cast(true))
-						.orderBy("entry.date", "asc")
-						.$narrowType<TNarrowed>(),
-				).as("entry"),
-			]),
-	queryOptions,
-);
-export type TRecurringConfigRow = ExtractRow<typeof recurringConfigsQuery>;
-
-export const groupsQuery = evolu.createQuery(
-	(db) =>
-		db.selectFrom("entryGroup").select(["id", "name"]).where("isDeleted", "is not", cast(true)).orderBy("createdAt"),
-	queryOptions,
-);
-
-export type TGroupsRow = Readonly<ExtractRow<typeof groupsQuery>>;
-
-export const tagsQuery = evolu.createQuery(
-	(db) =>
-		db
-			.selectFrom("entryTag")
-			.select(["id", "name", "color", "suggestId"])
-			.where("isDeleted", "is not", cast(true))
-			.where("name", "is not", null)
-			.where("color", "is not", null)
-			.$narrowType<{ name: NotNull }>()
-			.orderBy("createdAt"),
-	queryOptions,
-);
-
-export type TTagsRow = Readonly<ExtractRow<typeof tagsQuery>>;
-
-export const entriesQuery = evolu.createQuery(
-	(db) =>
-		db
-			.selectFrom("entry")
-			.select([
-				"id as entryId",
-				"name",
-				"type",
-				"currencyCode",
-				"amount",
-				"date",
-				"createdAt",
-				"fullfilled",
-				"recurringId",
-				"updatedAt",
-				"groupId",
-				"tagId",
-			])
-			.select((eb) => [
-				jsonObjectFrom(
-					eb
-						.selectFrom("entryGroup")
-						.select(["id as groupId", "name"])
-						.where("entryGroup.isDeleted", "is not", cast(true))
-						.whereRef("entryGroup.id", "=", "entry.groupId"),
-				).as("entryGroup"),
-			])
-			.select((eb) => [
-				jsonObjectFrom(
-					eb
-						.selectFrom("entryTag")
-						.select(["id as tagId", "name", "color"])
-						.where("entryTag.isDeleted", "is not", cast(true))
-						.whereRef("entryTag.id", "=", "entry.tagId"),
-				).as("entryTag"),
-			])
-			.where("isDeleted", "is not", cast(true))
-			.where("name", "is not", null)
-			.where("type", "is not", null)
-			.where("amount", "is not", null)
-			.where("recurringId", "is", null)
-			.$narrowType<TNarrowed>()
-			.orderBy("date", "asc"),
-	queryOptions,
-);
-
-export const deleteGroup = (groupId: TGroupId) => {
-	evolu.update("entryGroup", { id: groupId, isDeleted: true });
+export type TGroupRow = {
+        id: string;
+        name: string;
+        icon: string | null;
 };
 
-export const deleteTag = (tagId: TTagId) => {
-	evolu.update("entryTag", { id: tagId, isDeleted: true });
+export type TTagRow = {
+        id: string;
+        name: string;
+        color: string | null;
+        suggestId: string | null;
 };
 
-export const exclusionsQuery = (recurringId: TRecurringConfigId) =>
-	evolu.createQuery(
-		(db) =>
-			db
-				.selectFrom("exclusion")
-				.select(["id as exclusionId", "recurringId", "modifiedEntryId", "date", "reason"])
-				.where("isDeleted", "is not", cast(true))
-				.where("recurringId", "is", recurringId)
-				.$narrowType<{
-					recurringId: NotNull;
-					reason: NotNull;
-					date: NotNull;
-				}>()
-				.orderBy("createdAt"),
-		queryOptions,
-	);
+export type TEntryRow = {
+        entryId: string;
+        name: string;
+        type: "income" | "expense" | "assets";
+        currencyCode: string;
+        amount: string;
+        date: string;
+        createdAt: string;
+        fullfilled: boolean;
+        recurringId: string | null;
+        updatedAt: string | null;
+        groupId: string | null;
+        tagId: string | null;
+        entryGroup: EntryGroupInfo | null;
+        entryTag: EntryTagInfo | null;
+};
 
-export type TEntryRow = ExtractRow<typeof entriesQuery>;
-export type TExclusionRow = TRecurringConfigRow["exclusions"][number];
-export type TModifiedEntry = TExclusionRow["modifiedEntry"];
+export type TModifiedEntry = TEntryRow;
+
+export type TExclusionRow = {
+        exclusionId: string;
+        recurringId: string;
+        modifiedEntryId: string | null;
+        date: string;
+        reason: "deletion" | "modification";
+        createdAt: string;
+        modifiedEntry: TModifiedEntry | null;
+};
+
+export type TRecurringConfigRow = {
+        recurringConfigId: string;
+        frequency: "week" | "month" | "year";
+        interval: number;
+        every: number;
+        startDate: string;
+        endDate: string | null;
+        createdAt: string;
+        entry: TEntryRow | null;
+        exclusions: TExclusionRow[];
+};
+
+type TNarrowedEntry = NonNullable<TEntryRow>;
+
+type TOccurrence = {
+        index: number;
+        date: Date;
+        exclusionId: string | null;
+        modifiedEntry: TModifiedEntry | null;
+};
 
 export const generateOccurrences = (recurringConfig: TRecurringConfigRow, exclusions: TExclusionRow[]) => {
-	// console.time("generateOccurrences");
-	const occurences = [];
-	const MAX_OCCURENCES = {
-		year: 20,
-		month: 240,
-		week: 1248,
-	} as const;
+        const occurrences: TOccurrence[] = [];
+        const MAX_OCCURRENCES = {
+                year: 20,
+                month: 240,
+                week: 1248,
+        } as const;
 
-	const frequency = recurringConfig.frequency;
-	const every = recurringConfig.every || 1;
-	const startDate = dayjs(cast(recurringConfig.startDate!)).set("hour", 12); // set to noon to avoid DST issues
+        if (!recurringConfig.startDate) {
+                return occurrences;
+        }
 
-	let endDate = startDate.add(recurringConfig.interval!, frequency);
+        const frequency = recurringConfig.frequency;
+        const every = recurringConfig.every || 1;
+        const startDate = dayjs(recurringConfig.startDate).set("hour", 12);
 
-	if (recurringConfig.interval === 0) {
-		endDate = startDate.add(MAX_OCCURENCES[frequency], frequency);
-	}
+        let endDate = recurringConfig.interval
+                ? startDate.add(recurringConfig.interval, frequency)
+                : startDate.add(MAX_OCCURRENCES[frequency], frequency);
 
-	let diff = endDate.diff(startDate, frequency);
+        if (recurringConfig.interval === 0) {
+                endDate = startDate.add(MAX_OCCURRENCES[frequency], frequency);
+        }
 
-	if (diff < 0) {
-		diff = 0;
-	}
+        let diff = endDate.diff(startDate, frequency);
 
-	if (diff > MAX_OCCURENCES[frequency]) {
-		diff = MAX_OCCURENCES[frequency];
-	}
+        if (diff < 0) diff = 0;
+        if (diff > MAX_OCCURRENCES[frequency]) diff = MAX_OCCURRENCES[frequency];
 
-	let installment = 0;
-	for (let i = 0; i < diff; i += every) {
-		installment++;
-		const currDate = dayjs(startDate).add(i, frequency);
+        let installment = 0;
 
-		const isExcluded = exclusions.some((e) => currDate.isSame(dayjs(e.date), "day") && e.reason === "deletion");
+        for (let i = 0; i < diff; i += every) {
+                        installment++;
+                        const currentDate = dayjs(startDate).add(i, frequency);
 
-		const isModified = exclusions.find((e) => currDate.isSame(dayjs(e.date), "day") && e.reason === "modification");
+                        const exclusionForDay = exclusions.find((exclusion) =>
+                                currentDate.isSame(dayjs(exclusion.date), "day"),
+                        );
 
-		if (!isExcluded) {
-			occurences.push({
-				index: installment,
-				date: currDate.toDate(),
-				exclusionId: isModified ? isModified.id : null,
-				modifiedEntry: isModified ? isModified.modifiedEntry : null,
-			});
-		}
-	}
+                        if (exclusionForDay?.reason === "deletion") {
+                                continue;
+                        }
 
-	// console.timeEnd("generateOccurrences");
-	return occurences;
+                        occurrences.push({
+                                index: installment,
+                                date: currentDate.toDate(),
+                                exclusionId: exclusionForDay ? exclusionForDay.exclusionId : null,
+                                modifiedEntry: exclusionForDay?.modifiedEntry ?? null,
+                        });
+        }
+
+        return occurrences;
 };
 
-// needs a hard refactor
-export const populateEntries = (entries: Readonly<TEntryRow[]>, recurringConfigs: Readonly<TRecurringConfigRow[]>) => {
-	// console.time("populateEntries");
-	const entriesList: Array<{
-		id: null | TEntryId;
-		recurringConfigId: null | TRecurringConfigId;
-		exclusionId: null | TExclusionId;
-		index: number;
-		interval: number;
-		date: Date;
-		config: null | TConfig;
-		details: NonNullable<TEntryRow | TModifiedEntry>;
-	}> = [];
-	type TConfig = (typeof recurringConfigs)[0];
+export const populateEntries = (
+        entries: Readonly<TEntryRow[]>,
+        recurringConfigs: Readonly<TRecurringConfigRow[]>,
+) => {
+        const entriesList: Array<{
+                id: string | null;
+                recurringConfigId: string | null;
+                exclusionId: string | null;
+                index: number;
+                interval: number;
+                date: Date;
+                config: TRecurringConfigRow | null;
+                details: TNarrowedEntry;
+        }> = [];
 
-	recurringConfigs.forEach((recurringEntry) => {
-		const exclusions = recurringEntry.exclusions || [];
-		const occurrences = generateOccurrences(recurringEntry, exclusions);
-		occurrences.forEach((occ) => {
-			entriesList.push({
-				recurringConfigId: recurringEntry.recurringConfigId,
-				id: (occ.modifiedEntry?.entryId as TEntryId) || null,
-				exclusionId: (occ.exclusionId as TExclusionId) || null,
-				index: occ.index,
-				interval: recurringEntry.interval!,
-				config: recurringEntry,
-				date: occ.date,
-				details:
-					occ.modifiedEntry ||
-					({
-						...recurringEntry.entry,
-						fullfilled: cast(false),
-					} as NonNullable<TEntryRow>),
-			});
-		});
-	});
+        recurringConfigs.forEach((config) => {
+                const baseEntry = config.entry;
+                if (!baseEntry) return;
 
-	entries.forEach((entry) => {
-		entriesList.push({
-			id: entry.entryId,
-			index: 0,
-			interval: 0,
-			exclusionId: null,
-			recurringConfigId: null,
-			config: null,
-			date: cast(entry.date!),
-			details: entry,
-		});
-	});
+                const exclusions = config.exclusions || [];
+                const occurrences = generateOccurrences(config, exclusions);
 
-	entriesList.sort((a, b) => a.date.getTime() - b.date.getTime());
+                occurrences.forEach((occurrence) => {
+                        const details = occurrence.modifiedEntry || {
+                                ...baseEntry,
+                                fullfilled: false,
+                        };
 
-	// console.timeEnd("populateEntries");
-	return entriesList;
+                        entriesList.push({
+                                id: (occurrence.modifiedEntry?.entryId as string) || null,
+                                recurringConfigId: config.recurringConfigId,
+                                exclusionId: occurrence.exclusionId,
+                                index: occurrence.index,
+                                interval: config.interval,
+                                date: occurrence.date,
+                                config,
+                                details,
+                        });
+                });
+        });
+
+        entries.forEach((entry) => {
+                entriesList.push({
+                        id: entry.entryId,
+                        recurringConfigId: null,
+                        exclusionId: null,
+                        index: 0,
+                        interval: 0,
+                        date: new Date(entry.date),
+                        config: null,
+                        details: entry,
+                });
+        });
+
+        entriesList.sort((a, b) => a.date.getTime() - b.date.getTime());
+
+        return entriesList;
 };
 
 export type TPopulatedEntry = ReturnType<typeof populateEntries>[number];
+
 export const groupByCurrency = (entries: TPopulatedEntry[]) => {
-	return entries.reduce(
-		(acc, entry) => {
-			const currency = entry.details.currencyCode;
-			if (!acc[currency]) {
-				acc[currency] = [];
-			}
-			acc[currency].push(entry);
-			return acc;
-		},
-		{} as Record<string, TPopulatedEntry[]>,
-	);
+        return entries.reduce(
+                (acc, entry) => {
+                        const currency = entry.details.currencyCode;
+                        if (!acc[currency]) {
+                                acc[currency] = [];
+                        }
+                        acc[currency].push(entry);
+                        return acc;
+                },
+                {} as Record<string, TPopulatedEntry[]>,
+        );
 };
 
 export const calculateTotals = (groupedEntries: Record<string, TPopulatedEntry[]>) => {
-	return Object.entries(groupedEntries).reduce(
-		(acc, [currency, entries]) => {
-			acc[currency] = entries.reduce((acc, e) => acc + Number(e.details.amount), 0);
-			return acc;
-		},
-		{} as Record<string, number>,
-	);
+        return Object.entries(groupedEntries).reduce(
+                (acc, [currency, grouped]) => {
+                        acc[currency] = grouped.reduce((total, entry) => total + Number(entry.details.amount), 0);
+                        return acc;
+                },
+                {} as Record<string, number>,
+        );
 };
 
 export const calculatedFullfilledTotals = (groupedEntries: Record<string, TPopulatedEntry[]>) => {
-	return Object.entries(groupedEntries).reduce(
-		(acc, [currency, entries]) => {
-			acc[currency] = entries.filter((e) => e.details.fullfilled).reduce((acc, e) => acc + Number(e.details.amount), 0);
-			return acc;
-		},
-		{} as Record<string, number>,
-	);
+        return Object.entries(groupedEntries).reduce(
+                (acc, [currency, grouped]) => {
+                        acc[currency] = grouped
+                                .filter((entry) => entry.details.fullfilled)
+                                .reduce((total, entry) => total + Number(entry.details.amount), 0);
+                        return acc;
+                },
+                {} as Record<string, number>,
+        );
 };
 
 type TCALCULATIONS_OUTPUT = Record<
-	number,
-	{
-		month: Dayjs;
-		income: TPopulatedEntry[];
-		expense: TPopulatedEntry[];
-		assets: TPopulatedEntry[]; // not implemented yet
-		// groupedByCurrency: {
-		// 	income: Record<
-		// 		string,
-		// 		{
-		// 			entries: TPopulatedEntry[];
-		// 			expected: number;
-		// 			fullfilled: number;
-		// 			remaining: number;
-		// 		}
-		// 	>;
-		// 	expense: Record<
-		// 		string,
-		// 		{
-		// 			entries: TPopulatedEntry[];
-		// 			expected: number;
-		// 			fullfilled: number;
-		// 			remaining: number;
-		// 		}
-		// 	>;
-		// };
-		// ---
-		incomesGroupedByCurrency: Record<string, TPopulatedEntry[]>;
-		totalExpectedIncomeGroupedByCurrency: Record<string, number>;
-		totalReceivedIncomeGroupedByCurrency: Record<string, number>;
-		totalRemainingIncomeGroupedByCurrency: Record<string, number>;
-		// ---
-		expensesGroupedByCurrency: Record<string, TPopulatedEntry[]>;
-		totalExpectedExpenseGroupedByCurrency: Record<string, number>;
-		totalPaidExpenseGroupedByCurrency: Record<string, number>;
-		totalRemainingExpenseGroupedByCurrency: Record<string, number>;
-		// ---
-		result: {
-			inMainCurrency: {
-				actual: {
-					income: number;
-					expense: number;
-					total: number;
-				};
-				foresight: {
-					income: number;
-					expense: number;
-					total: number;
-				};
-			};
-			actual: Record<string, number>;
-			foresight: Record<string, number>;
-		};
-	}
->;
-export type TCALCULATIONS_OUTPUT_V2 = Record<
-	number,
-	{
-		month: Dayjs;
-		income: TPopulatedEntry[];
-		expense: TPopulatedEntry[];
-		assets: TPopulatedEntry[]; // not implemented yet
-		grouped: {
-			income: Record<
-				string,
-				{
-					entries: TPopulatedEntry[];
-					expected: number;
-					fullfilled: number;
-					remaining: number;
-				}
-			>;
-			expense: Record<
-				string,
-				{
-					entries: TPopulatedEntry[];
-					expected: number;
-					fullfilled: number;
-					remaining: number;
-				}
-			>;
-		};
-		// ---
-		result: {
-			inMainCurrency: {
-				actual: {
-					income: number;
-					expense: number;
-					total: number;
-				};
-				foresight: {
-					income: number;
-					expense: number;
-					total: number;
-				};
-			};
-			actual: Record<string, number>;
-			foresight: Record<string, number>;
-		};
-	}
+        number,
+        {
+                month: Dayjs;
+                income: TPopulatedEntry[];
+                expense: TPopulatedEntry[];
+                assets: TPopulatedEntry[];
+                grouped: {
+                        income: Record<
+                                string,
+                                {
+                                        entries: TPopulatedEntry[];
+                                        expected: number;
+                                        fullfilled: number;
+                                        remaining: number;
+                                }
+                        >;
+                        expense: Record<
+                                string,
+                                {
+                                        entries: TPopulatedEntry[];
+                                        expected: number;
+                                        fullfilled: number;
+                                        remaining: number;
+                                }
+                        >;
+                };
+                result: {
+                        inMainCurrency: {
+                                actual: {
+                                        income: number;
+                                        expense: number;
+                                        total: number;
+                                };
+                                foresight: {
+                                        income: number;
+                                        expense: number;
+                                        total: number;
+                                };
+                        };
+                        actual: Record<string, number>;
+                        foresight: Record<string, number>;
+                };
+        }
 >;
 
-/**
- * @deprecated
- */
-export const getCalculations = ({
-	rates,
-	viewportStartDate,
-	viewportEndDate,
-	populatedEntries,
-	groupFilters,
-	tagFilters,
-}: {
-	rates: Record<string, number>;
-	viewportStartDate: dayjs.Dayjs;
-	viewportEndDate: dayjs.Dayjs;
-	populatedEntries: TPopulatedEntry[];
-	groupFilters?: (TGroupId | "no-group")[];
-	tagFilters?: (TTagId | "no-tag")[];
-	monthFilter?: string;
-}) => {
-	// console.time("getCalculations");
-	const CALCULATIONS: TCALCULATIONS_OUTPUT = {};
-
-	let month: Dayjs = viewportStartDate;
-	const totalMonthCount = viewportEndDate.diff(viewportStartDate, "month");
-	const mainCurrency = localStorage.getItem(storageKeys.mainCurrency) || "TRY"; // TODO: get it from args
-
-	if (groupFilters && groupFilters.length > 0) {
-		populatedEntries = populatedEntries.filter((entry) => groupFilters.includes(entry.details.groupId || "no-group"));
-	}
-
-	if (tagFilters && tagFilters.length > 0) {
-		populatedEntries = populatedEntries.filter((entry) => tagFilters.includes(entry.details.tagId || "no-tag"));
-	}
-
-	for (let i = 0; i <= totalMonthCount; i++) {
-		month = viewportStartDate.add(i, "month");
-		const monthEntries = populatedEntries.filter(
-			(e) => dayjs(e.date).month() === month.month() && dayjs(e.date).year() === month.year(),
-		);
-
-		const income = monthEntries.filter((e) => e.details.type === "income");
-		const expense = monthEntries.filter((e) => e.details.type === "expense");
-
-		const incomesGroupedByCurrency = groupByCurrency(income);
-		const expensesGroupedByCurrency = groupByCurrency(expense);
-
-		const allUsedCurrencies = new Set([
-			...Object.keys(incomesGroupedByCurrency),
-			...Object.keys(expensesGroupedByCurrency),
-		]);
-
-		const isDifferentCurrencyUsed = Array.from(allUsedCurrencies).some((currency) => currency !== mainCurrency);
-
-		const totalExpectedIncomeGroupedByCurrency = calculateTotals(incomesGroupedByCurrency);
-		const totalReceivedIncomeGroupedByCurrency = calculatedFullfilledTotals(incomesGroupedByCurrency);
-
-		const totalExpectedExpenseGroupedByCurrency = calculateTotals(expensesGroupedByCurrency);
-
-		const totalPaidExpenseGroupedByCurrency = calculatedFullfilledTotals(expensesGroupedByCurrency);
-
-		const resultGroupedByCurrencyForesight = Object.entries(totalExpectedIncomeGroupedByCurrency).reduce(
-			(acc, [currency]) => {
-				acc[currency] =
-					(totalExpectedIncomeGroupedByCurrency[currency] || 0) -
-					(totalExpectedExpenseGroupedByCurrency[currency] || 0);
-
-				return acc;
-			},
-			{} as Record<string, number>,
-		);
-
-		const resultGroupedByCurrency = Object.entries(totalExpectedIncomeGroupedByCurrency).reduce(
-			(acc, [currency]) => {
-				acc[currency] =
-					(totalReceivedIncomeGroupedByCurrency[currency] || 0) - (totalPaidExpenseGroupedByCurrency[currency] || 0);
-
-				return acc;
-			},
-			{} as Record<string, number>,
-		);
-
-		const missingCurrencies = Object.keys(totalExpectedExpenseGroupedByCurrency).filter(
-			(currency) => !resultGroupedByCurrency.hasOwnProperty(currency),
-		);
-
-		const missingCurrenciesForsight = Object.keys(totalExpectedExpenseGroupedByCurrency).filter(
-			(currency) => !resultGroupedByCurrencyForesight.hasOwnProperty(currency),
-		);
-
-		missingCurrencies.forEach((currency) => {
-			resultGroupedByCurrency[currency] = -totalPaidExpenseGroupedByCurrency[currency];
-		});
-
-		missingCurrenciesForsight.forEach((currency) => {
-			resultGroupedByCurrencyForesight[currency] = -totalExpectedExpenseGroupedByCurrency[currency];
-		});
-
-		let inMainCurrencyActualIncome = 0;
-		let inMainCurrencyForesightIncome = 0;
-		let inMainCurrencyActualExpense = 0;
-		let inMainCurrencyForsightExpense = 0;
-
-		if (isDifferentCurrencyUsed && Object.keys(rates).length > 0) {
-			inMainCurrencyActualIncome = Object.entries(totalReceivedIncomeGroupedByCurrency).reduce(
-				(acc, [currency, amount]) => {
-					if (rates[currency]) acc += amount * rates[currency];
-					return acc;
-				},
-				0,
-			);
-
-			inMainCurrencyActualExpense = Object.entries(totalPaidExpenseGroupedByCurrency).reduce(
-				(acc, [currency, amount]) => {
-					if (rates[currency]) acc += amount * rates[currency];
-					return acc;
-				},
-				0,
-			);
-
-			inMainCurrencyForesightIncome = Object.entries(totalExpectedIncomeGroupedByCurrency).reduce(
-				(acc, [currency, amount]) => {
-					if (rates[currency]) acc += amount * rates[currency];
-					return acc;
-				},
-				0,
-			);
-
-			inMainCurrencyForsightExpense = Object.entries(totalExpectedExpenseGroupedByCurrency).reduce(
-				(acc, [currency, amount]) => {
-					if (rates[currency]) acc += amount * rates[currency];
-					return acc;
-				},
-				0,
-			);
-		}
-
-		const inMainCurrency = isDifferentCurrencyUsed
-			? {
-					actual: {
-						income: inMainCurrencyActualIncome,
-						expense: inMainCurrencyActualExpense,
-						total: inMainCurrencyActualIncome - inMainCurrencyActualExpense,
-					},
-					foresight: {
-						income: inMainCurrencyForesightIncome,
-						expense: inMainCurrencyForsightExpense,
-						total: inMainCurrencyForesightIncome - inMainCurrencyForsightExpense,
-					},
-				}
-			: {
-					actual: {
-						income: totalReceivedIncomeGroupedByCurrency[mainCurrency],
-						expense: totalPaidExpenseGroupedByCurrency[mainCurrency],
-						total: resultGroupedByCurrency[mainCurrency],
-					},
-					foresight: {
-						income: totalExpectedIncomeGroupedByCurrency[mainCurrency],
-						expense: totalExpectedExpenseGroupedByCurrency[mainCurrency],
-						total: resultGroupedByCurrencyForesight[mainCurrency],
-					},
-				};
-
-		CALCULATIONS[i] = {
-			month,
-			income,
-			expense,
-			assets: [],
-			incomesGroupedByCurrency,
-			totalExpectedIncomeGroupedByCurrency,
-			totalReceivedIncomeGroupedByCurrency,
-			totalRemainingIncomeGroupedByCurrency: Object.entries(totalExpectedIncomeGroupedByCurrency).reduce(
-				(acc, [currency, amount]) => {
-					acc[currency] = amount - (totalReceivedIncomeGroupedByCurrency[currency] || 0);
-					return acc;
-				},
-				{} as Record<string, number>,
-			),
-			expensesGroupedByCurrency,
-			totalExpectedExpenseGroupedByCurrency,
-			totalPaidExpenseGroupedByCurrency,
-			totalRemainingExpenseGroupedByCurrency: Object.entries(totalExpectedExpenseGroupedByCurrency).reduce(
-				(acc, [currency, amount]) => {
-					acc[currency] = amount - (totalPaidExpenseGroupedByCurrency[currency] || 0);
-					return acc;
-				},
-				{} as Record<string, number>,
-			),
-			result: {
-				inMainCurrency,
-				actual: resultGroupedByCurrency,
-				foresight: resultGroupedByCurrencyForesight,
-			},
-		};
-	}
-	// console.timeEnd("getCalculations");
-	return CALCULATIONS;
-};
+export type TCALCULATIONS_OUTPUT_V2 = TCALCULATIONS_OUTPUT;
 
 export const getCalculations_v2 = ({
-	rates,
-	viewportStartDate,
-	viewportEndDate,
-	populatedEntries,
-	groupFilters,
-	tagFilters,
-	mainCurrency,
+        rates,
+        viewportStartDate,
+        viewportEndDate,
+        populatedEntries,
+        groupFilters,
+        tagFilters,
+        mainCurrency,
 }: {
-	rates: Record<string, number>;
-	viewportStartDate: dayjs.Dayjs;
-	viewportEndDate: dayjs.Dayjs;
-	populatedEntries: TPopulatedEntry[];
-	groupFilters?: (TGroupId | "no-group")[];
-	tagFilters?: (TTagId | "no-tag")[];
-	mainCurrency: string;
+        rates: Record<string, number>;
+        viewportStartDate: dayjs.Dayjs;
+        viewportEndDate: dayjs.Dayjs;
+        populatedEntries: TPopulatedEntry[];
+        groupFilters?: (TGroupId | "no-group")[];
+        tagFilters?: (TTagId | "no-tag")[];
+        mainCurrency: string;
 }) => {
-	// console.time("getCalculations_v2");
-	const CALC: TCALCULATIONS_OUTPUT_V2 = {};
+        const CALC: TCALCULATIONS_OUTPUT_V2 = {};
 
-	let month: Dayjs = viewportStartDate;
-	const totalMonthCount = viewportEndDate.diff(viewportStartDate, "month");
+        let month: Dayjs = viewportStartDate;
+        const totalMonthCount = viewportEndDate.diff(viewportStartDate, "month");
 
-	if (groupFilters && groupFilters.length > 0) {
-		populatedEntries = populatedEntries.filter((entry) => groupFilters.includes(entry.details.groupId || "no-group"));
-	}
+        let filteredEntries = populatedEntries;
 
-	if (tagFilters && tagFilters.length > 0) {
-		populatedEntries = populatedEntries.filter((entry) => tagFilters.includes(entry.details.tagId || "no-tag"));
-	}
+        if (groupFilters && groupFilters.length > 0) {
+                filteredEntries = filteredEntries.filter((entry) =>
+                        groupFilters.includes((entry.details.groupId as TGroupId | null) || "no-group"),
+                );
+        }
 
-	for (let i = 0; i <= totalMonthCount; i++) {
-		month = viewportStartDate.add(i, "month");
-		CALC[i] = {
-			month,
-			income: [],
-			expense: [],
-			assets: [],
-			grouped: {
-				income: {},
-				expense: {},
-			},
-			result: {
-				inMainCurrency: {
-					actual: {
-						income: 0,
-						expense: 0,
-						total: 0,
-					},
-					foresight: { income: 0, expense: 0, total: 0 },
-				},
-				actual: {},
-				foresight: {},
-			},
-		};
+        if (tagFilters && tagFilters.length > 0) {
+                filteredEntries = filteredEntries.filter((entry) =>
+                        tagFilters.includes((entry.details.tagId as TTagId | null) || "no-tag"),
+                );
+        }
 
-		const monthEntries = populatedEntries.filter(
-			(e) => dayjs(e.date).month() === month.month() && dayjs(e.date).year() === month.year(),
-		);
+        for (let i = 0; i <= totalMonthCount; i++) {
+                month = viewportStartDate.add(i, "month");
+                CALC[i] = {
+                        month,
+                        income: [],
+                        expense: [],
+                        assets: [],
+                        grouped: {
+                                income: {},
+                                expense: {},
+                        },
+                        result: {
+                                inMainCurrency: {
+                                        actual: { income: 0, expense: 0, total: 0 },
+                                        foresight: { income: 0, expense: 0, total: 0 },
+                                },
+                                actual: {},
+                                foresight: {},
+                        },
+                };
 
-		const allUsedCurrencies = new Set<string>();
+                const monthEntries = filteredEntries.filter(
+                        (entry) =>
+                                dayjs(entry.date).month() === month.month() && dayjs(entry.date).year() === month.year(),
+                );
 
-		monthEntries.map((entry) => {
-			const currency = entry.details.currencyCode;
-			const type = entry.details.type;
-			const isFullfilled = !!entry.details.fullfilled;
-			const amount = Number(entry.details.amount);
-			const actualAmount = isFullfilled ? amount : 0;
+                const currenciesUsed = new Set<string>();
 
-			CALC[i][type].push(entry);
+                monthEntries.forEach((entry) => {
+                        const currency = entry.details.currencyCode;
+                        const type = entry.details.type;
+                        const isFullfilled = !!entry.details.fullfilled;
+                        const amount = Number(entry.details.amount);
+                        const actualAmount = isFullfilled ? amount : 0;
 
-			allUsedCurrencies.add(currency);
+                        if (type === "income") {
+                                CALC[i].income.push(entry);
+                        } else if (type === "expense") {
+                                CALC[i].expense.push(entry);
+                        } else {
+                                CALC[i].assets.push(entry);
+                        }
 
-			CALC[i].grouped[type][currency] ??= {
-				entries: [],
-				expected: 0,
-				fullfilled: 0,
-				remaining: 0,
-			};
+                        currenciesUsed.add(currency);
 
-			CALC[i].grouped[type][currency].entries.push(entry);
-			CALC[i].grouped[type][currency].expected += amount;
-			CALC[i].grouped[type][currency].fullfilled += isFullfilled ? amount : 0;
-			CALC[i].grouped[type][currency].remaining += isFullfilled ? 0 : amount;
+                        CALC[i].grouped[type][currency] ??= {
+                                entries: [],
+                                expected: 0,
+                                fullfilled: 0,
+                                remaining: 0,
+                        };
 
-			CALC[i].result.actual[currency] ??= 0;
-			CALC[i].result.foresight[currency] ??= 0;
+                        CALC[i].grouped[type][currency].entries.push(entry);
+                        CALC[i].grouped[type][currency].expected += amount;
+                        CALC[i].grouped[type][currency].fullfilled += isFullfilled ? amount : 0;
+                        CALC[i].grouped[type][currency].remaining += isFullfilled ? 0 : amount;
 
-			CALC[i].result.actual[currency] += type === "expense" ? -1 * actualAmount : actualAmount;
-			CALC[i].result.foresight[currency] += type === "expense" ? -1 * amount : amount;
+                        CALC[i].result.actual[currency] ??= 0;
+                        CALC[i].result.foresight[currency] ??= 0;
 
-			CALC[i].result.inMainCurrency.actual[type] += actualAmount;
-			CALC[i].result.inMainCurrency.foresight[type] += amount;
-		});
+                        CALC[i].result.actual[currency] += type === "expense" ? -1 * actualAmount : actualAmount;
+                        CALC[i].result.foresight[currency] += type === "expense" ? -1 * amount : amount;
 
-		const isDifferentCurrencyUsed = Array.from(allUsedCurrencies).some((currency) => currency !== mainCurrency);
+                        CALC[i].result.inMainCurrency.actual[type === "expense" ? "expense" : "income"] += actualAmount;
+                        CALC[i].result.inMainCurrency.foresight[type === "expense" ? "expense" : "income"] += amount;
+                });
 
-		if (!isDifferentCurrencyUsed) {
-			CALC[i].result.inMainCurrency.actual.total =
-				CALC[i].result.inMainCurrency.actual.income - CALC[i].result.inMainCurrency.actual.expense;
+                const usesDifferentCurrency = Array.from(currenciesUsed).some((currency) => currency !== mainCurrency);
 
-			CALC[i].result.inMainCurrency.foresight.total =
-				CALC[i].result.inMainCurrency.foresight.income - CALC[i].result.inMainCurrency.foresight.expense;
-		} else {
-			if (Object.keys(rates).length > 0) {
-				CALC[i].result.inMainCurrency.actual.income = Object.entries(CALC[i].grouped.income).reduce(
-					(acc, [currency, data]) => {
-						acc += data.fullfilled * rates[currency];
-						return acc;
-					},
-					0,
-				);
+                if (!usesDifferentCurrency) {
+                        CALC[i].result.inMainCurrency.actual.total =
+                                CALC[i].result.inMainCurrency.actual.income - CALC[i].result.inMainCurrency.actual.expense;
 
-				CALC[i].result.inMainCurrency.actual.expense = Object.entries(CALC[i].grouped.expense).reduce(
-					(acc, [currency, data]) => {
-						acc += data.fullfilled * rates[currency];
-						return acc;
-					},
-					0,
-				);
+                        CALC[i].result.inMainCurrency.foresight.total =
+                                CALC[i].result.inMainCurrency.foresight.income - CALC[i].result.inMainCurrency.foresight.expense;
+                } else if (Object.keys(rates).length > 0) {
+                        CALC[i].result.inMainCurrency.actual.income = Object.entries(CALC[i].grouped.income).reduce(
+                                (acc, [currency, data]) => acc + data.fullfilled * (rates[currency] ?? 0),
+                                0,
+                        );
 
-				CALC[i].result.inMainCurrency.actual.total =
-					CALC[i].result.inMainCurrency.actual.income - CALC[i].result.inMainCurrency.actual.expense;
+                        CALC[i].result.inMainCurrency.actual.expense = Object.entries(CALC[i].grouped.expense).reduce(
+                                (acc, [currency, data]) => acc + data.fullfilled * (rates[currency] ?? 0),
+                                0,
+                        );
 
-				CALC[i].result.inMainCurrency.foresight.income = Object.entries(CALC[i].grouped.income).reduce(
-					(acc, [currency, data]) => {
-						acc += data.expected * rates[currency];
-						return acc;
-					},
-					0,
-				);
+                        CALC[i].result.inMainCurrency.actual.total =
+                                CALC[i].result.inMainCurrency.actual.income - CALC[i].result.inMainCurrency.actual.expense;
 
-				CALC[i].result.inMainCurrency.foresight.expense = Object.entries(CALC[i].grouped.expense).reduce(
-					(acc, [currency, data]) => {
-						acc += data.expected * rates[currency];
-						return acc;
-					},
-					0,
-				);
+                        CALC[i].result.inMainCurrency.foresight.income = Object.entries(CALC[i].grouped.income).reduce(
+                                (acc, [currency, data]) => acc + data.expected * (rates[currency] ?? 0),
+                                0,
+                        );
 
-				CALC[i].result.inMainCurrency.foresight.total =
-					CALC[i].result.inMainCurrency.foresight.income - CALC[i].result.inMainCurrency.foresight.expense;
-			}
-		}
-	}
-	// console.timeEnd("getCalculations_v2");
-	return CALC;
+                        CALC[i].result.inMainCurrency.foresight.expense = Object.entries(CALC[i].grouped.expense).reduce(
+                                (acc, [currency, data]) => acc + data.expected * (rates[currency] ?? 0),
+                                0,
+                        );
+
+                        CALC[i].result.inMainCurrency.foresight.total =
+                                CALC[i].result.inMainCurrency.foresight.income -
+                                CALC[i].result.inMainCurrency.foresight.expense;
+                }
+        }
+
+        return CALC;
 };
 
-export type TCalculations = ReturnType<typeof getCalculations>;
-
-export function getEntries<T extends object>(obj: T) {
-	const mainCurrency = localStorage.getItem(storageKeys.mainCurrency) || "TRY";
-	return Object.entries(obj).length ? Object.entries(obj) : [[mainCurrency, "0.00000000"]];
-}
-
-export function toggleFullfilled(entry: TPopulatedEntry) {
-	// if it's an exclusion
-	if (entry.exclusionId && entry.details.entryId) {
-		evolu.update("entry", {
-			id: entry.details.entryId as TEntryId,
-			fullfilled: !entry.details.fullfilled,
-		});
-		// if it's a single entry
-	} else if (entry.id && !entry.recurringConfigId) {
-		evolu.update("entry", {
-			id: entry.id,
-			fullfilled: !entry.details.fullfilled,
-		});
-		// if its's a ghost record
-	} else if (entry.recurringConfigId) {
-		const newEntry = evolu.create("entry", {
-			...entry.details,
-			fullfilled: !entry.details.fullfilled,
-		});
-		evolu.create("exclusion", {
-			recurringId: entry.recurringConfigId,
-			date: entry.date,
-			reason: "modification",
-			modifiedEntryId: newEntry.id,
-		});
-	}
-}
-
-export async function deleteEntry(entry: TPopulatedEntry, withSubsequents = false, onComplete: () => void = () => {}) {
-	// if it's an exclusion
-	if (entry.exclusionId) {
-		evolu.update("exclusion", {
-			id: entry.exclusionId,
-			reason: "deletion",
-		});
-		// if it's a single entry
-	} else if (entry.id && !entry.recurringConfigId) {
-		evolu.update("entry", { id: entry.id, isDeleted: true });
-	} else {
-		// if its's a ghost record
-		evolu.create("exclusion", {
-			recurringId: entry.recurringConfigId!,
-			date: entry.date,
-			reason: "deletion",
-			modifiedEntryId: null,
-		});
-	}
-
-	if (withSubsequents && entry.recurringConfigId) {
-		const allExclusions = await evolu.loadQuery(exclusionsQuery(entry.recurringConfigId));
-
-		if (entry.index === 0) {
-			// we are deleting main entry, so delete recurring config also
-			evolu.update("recurringConfig", {
-				id: entry.recurringConfigId,
-				isDeleted: true,
-			});
-
-			allExclusions.rows.map((ex) => {
-				evolu.update("exclusion", {
-					id: ex.exclusionId,
-					isDeleted: true,
-				});
-			});
-		} else {
-			// delete exclusions after this date
-			allExclusions.rows
-				.filter((ex) => dayjs(ex.date).isAfter(dayjs(entry.date)))
-				.map((ex) => {
-					evolu.update("exclusion", {
-						id: ex.exclusionId,
-						isDeleted: true,
-					});
-				});
-
-			// modify main entry's endDate and internal
-			evolu.update("recurringConfig", {
-				id: entry.recurringConfigId,
-				endDate: entry.date,
-				every: entry.config?.every || 1,
-				interval: entry.index - 1,
-				isDeleted: entry.index - 1 === 0, // if it's the last one, mark as deleted
-			});
-		}
-	}
-
-	setTimeout(() => {
-		// we need to wait for the dialog to close
-		// because the entry is still open
-		onComplete();
-	}, 200);
-}
-
-export async function editEntry(
-	entry: TPopulatedEntry,
-	newName: string,
-	newAmount: string,
-	newGroup: string | null,
-	newTag: string | null,
-	onComplete: () => void,
-	applyToSubsequents = false,
-) {
-	if (!newName || newName.length === 0) return;
-	if (!newAmount || newAmount.length === 0) return;
-
-	newGroup = newGroup === "" ? null : newGroup;
-	newTag = newTag === "" ? null : newTag;
-
-	const newValues = {
-		name: decodeName(newName),
-		amount: decodeAmount(Number(newAmount).toFixed(8).toString()),
-		groupId: newGroup as TGroupId | null,
-		tagId: newTag as TTagId | null,
-	};
-
-	// if it's an exclusion
-	if (entry.exclusionId && entry.details.entryId) {
-		evolu.update("entry", {
-			id: entry.details.entryId as TEntryId,
-			...newValues,
-		});
-		// if it's a single entry
-	} else if (entry.id && !entry.recurringConfigId) {
-		evolu.update("entry", {
-			id: entry.id,
-			...newValues,
-		});
-		// if its's a ghost record
-	} else if (entry.recurringConfigId && !entry.exclusionId) {
-		// create a new entry and exclusion for that date
-		const newEntry = evolu.create("entry", {
-			...entry.details,
-			...newValues,
-			fullfilled: false,
-		});
-		evolu.create("exclusion", {
-			recurringId: entry.recurringConfigId,
-			date: entry.date,
-			reason: "modification",
-			modifiedEntryId: newEntry.id,
-		});
-	}
-
-	if (applyToSubsequents && entry.recurringConfigId && entry.config) {
-		const allExclusions = await evolu.loadQuery(exclusionsQuery(entry.recurringConfigId));
-
-		// if we are modifiying a main entry and there is no occurrences
-		// just update the main entry
-		if (
-			allExclusions.rows.length === 0 &&
-			entry.details.entryId
-			// && entry.index === 1
-		) {
-			evolu.update("entry", {
-				id: entry.details.entryId as TEntryId,
-				...newValues,
-			});
-
-			onComplete();
-			return;
-		}
-
-		// mark deletion to all exclusions after this date
-		allExclusions.rows
-			.filter((ex) => dayjs(ex.date).isAfter(dayjs(entry.date)))
-			.map((ex) => {
-				evolu.update("exclusion", {
-					id: ex.exclusionId,
-					reason: "deletion",
-				});
-			});
-
-		// delete self
-		evolu.create("exclusion", {
-			recurringId: entry.recurringConfigId!,
-			date: entry.date,
-			reason: "deletion",
-		});
-
-		// stop old recurring config and delete if needed
-		evolu.update("recurringConfig", {
-			id: entry.recurringConfigId,
-			endDate: entry.date,
-			every: entry.config.every || 1,
-			interval: entry.index - 1,
-			isDeleted: entry.index - 1 === 0,
-		});
-
-		// create new recurring config
-		const newRecurring = evolu.create("recurringConfig", {
-			...entry.config,
-			startDate: entry.date,
-			endDate: entry.config.endDate,
-			every: entry.config.every || 1,
-			interval: entry.config.interval ? entry.config.interval - entry.index + 1 : 0,
-		});
-
-		// new entry
-		const newModifiedEntry = evolu.create("entry", {
-			...entry.details,
-			...newValues,
-			fullfilled: cast(!!entry.details.fullfilled),
-			recurringId: newRecurring.id,
-		});
-
-		// create new exclusion
-		evolu.create("exclusion", {
-			recurringId: newRecurring.id,
-			date: entry.date,
-			reason: "modification",
-			modifiedEntryId: newModifiedEntry.id,
-		});
-	}
-
-	onComplete();
+export function getEntries(obj: Record<string, number>) {
+        const mainCurrency = localStorage.getItem(storageKeys.mainCurrency) || "TRY";
+        return Object.entries(obj).length ? Object.entries(obj) : [[mainCurrency, 0]];
 }
 
 export function sum(a: number, b: number) {
-	return a + b;
+        return a + b;
 }

--- a/src/lib/supabase-client.ts
+++ b/src/lib/supabase-client.ts
@@ -1,0 +1,53 @@
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+export interface SupabaseResponse<T> {
+        data: T | null;
+        error: Error | null;
+}
+
+const createHeaders = () => {
+        if (!supabaseUrl || !supabaseAnonKey) {
+                console.warn("Supabase environment variables are not configured.");
+                return null;
+        }
+
+        return {
+                apikey: supabaseAnonKey,
+                Authorization: `Bearer ${supabaseAnonKey}`,
+        } satisfies Record<string, string>;
+};
+
+export const supabaseRequest = async <T>(path: string, init: RequestInit = {}): Promise<SupabaseResponse<T>> => {
+        const headers = createHeaders();
+        if (!supabaseUrl || !headers) {
+                return { data: null, error: new Error("Supabase environment variables are not configured.") };
+        }
+
+        const requestHeaders = new Headers({
+                ...headers,
+                "Content-Type": "application/json",
+                ...init.headers,
+        });
+
+        try {
+                const response = await fetch(`${supabaseUrl}/rest/v1/${path}`, {
+                        ...init,
+                        headers: requestHeaders,
+                });
+
+                if (!response.ok) {
+                        const message = await response.text();
+                        return { data: null, error: new Error(message || response.statusText) };
+                }
+
+                if (response.status === 204) {
+                        return { data: null, error: null };
+                }
+
+                const data = (await response.json()) as T;
+                return { data, error: null };
+        } catch (error) {
+                return { data: null, error: error as Error };
+        }
+};

--- a/src/lib/utils.tsx
+++ b/src/lib/utils.tsx
@@ -1,6 +1,5 @@
 import type { TDecimalMode } from "@/providers/localization";
 import type { Theme } from "@/providers/theme";
-import type { Mnemonic } from "@evolu/react";
 import * as bip39 from "@scure/bip39";
 import { wordlist } from "@scure/bip39/wordlists/english";
 import { type ClassValue, clsx } from "clsx";
@@ -257,19 +256,20 @@ export const defaultCurrencyDecimalPlaces = new Map([
 const storagePrefix = "giderim";
 
 export const storageKeys = {
-	lang: `${storagePrefix}-lang`,
-	theme: `${storagePrefix}-theme`,
-	mainCurrency: `${storagePrefix}-main-currency`,
-	decimal: `${storagePrefix}-decimal`,
-	decimalMode: `${storagePrefix}-decimal-mode`,
-	tinyDecimal: `${storagePrefix}-tiny-decimal`,
-	monthTabs: `${storagePrefix}-month-tabs`, // @deprecated
-	onboarding: `${storagePrefix}-onboarding`,
-	firstShowAnimation: `${storagePrefix}-first-show-animation`,
-	activeScreen: `${storagePrefix}-active-screen`,
-	calendarType: `${storagePrefix}-calendar-type`,
-	calendarVision: `${storagePrefix}-calendar-vision`,
-	calendarIndex: `${storagePrefix}-calendar-index`,
+        lang: `${storagePrefix}-lang`,
+        theme: `${storagePrefix}-theme`,
+        mainCurrency: `${storagePrefix}-main-currency`,
+        decimal: `${storagePrefix}-decimal`,
+        decimalMode: `${storagePrefix}-decimal-mode`,
+        tinyDecimal: `${storagePrefix}-tiny-decimal`,
+        monthTabs: `${storagePrefix}-month-tabs`, // @deprecated
+        onboarding: `${storagePrefix}-onboarding`,
+        firstShowAnimation: `${storagePrefix}-first-show-animation`,
+        activeScreen: `${storagePrefix}-active-screen`,
+        calendarType: `${storagePrefix}-calendar-type`,
+        calendarVision: `${storagePrefix}-calendar-vision`,
+        calendarIndex: `${storagePrefix}-calendar-index`,
+        privateKey: `${storagePrefix}-private-key`,
 };
 
 export async function minDelay<T>(promise: Promise<T>, ms: number) {
@@ -291,8 +291,8 @@ export const STAGGER_CHILD_VARIANTS = {
 };
 
 export const validateMnemonic = (mnemonic: string) => {
-	const mnemonicTrimmed = mnemonic.trim();
-	return bip39.validateMnemonic(mnemonicTrimmed, wordlist) ? (mnemonicTrimmed as Mnemonic) : null;
+        const mnemonicTrimmed = mnemonic.trim();
+        return bip39.validateMnemonic(mnemonicTrimmed, wordlist) ? mnemonicTrimmed : null;
 };
 
 export function setThemeColor(theme: Theme) {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,4 @@
 import { Toaster } from "@/components/ui/toaster";
-import { evolu } from "@/evolu-db.ts";
 import { storageKeys } from "@/lib/utils.tsx";
 
 import {
@@ -11,7 +10,7 @@ import { FiltersProvider } from "@/providers/filters.tsx";
 import { LocalizationProvider } from "@/providers/localization.tsx";
 import { type Theme, ThemeProvider } from "@/providers/theme.tsx";
 import UpdatePrompt from "@/update-prompt.tsx";
-import { EvoluProvider } from "@evolu/react";
+import { DataProvider } from "@/providers/data";
 import "dayjs/locale/en";
 import "dayjs/locale/tr";
 import React, { Suspense } from "react";
@@ -31,18 +30,18 @@ window.oncontextmenu = () => false;
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
 	<React.StrictMode>
-		<EvoluProvider value={evolu}>
-			<FiltersProvider>
-				<ThemeProvider defaultTheme={localTheme}>
-					<LocalizationProvider defaultLang={localLang}>
-						<App />
-						<Toaster />
-						<Suspense>
-							<UpdatePrompt />
-						</Suspense>
-					</LocalizationProvider>
-				</ThemeProvider>
-			</FiltersProvider>
-		</EvoluProvider>
-	</React.StrictMode>,
+                <DataProvider>
+                        <FiltersProvider>
+                                <ThemeProvider defaultTheme={localTheme}>
+                                        <LocalizationProvider defaultLang={localLang}>
+                                                <App />
+                                                <Toaster />
+                                                <Suspense>
+                                                        <UpdatePrompt />
+                                                </Suspense>
+                                        </LocalizationProvider>
+                                </ThemeProvider>
+                        </FiltersProvider>
+                </DataProvider>
+        </React.StrictMode>,
 );

--- a/src/providers/data.tsx
+++ b/src/providers/data.tsx
@@ -1,0 +1,892 @@
+import { useCallback, useEffect, useState } from "react";
+
+import {
+        DataContext,
+        type CreateEntryInput,
+        type CreateRecurringConfigInput,
+        type DataContextValue,
+        type EditEntryInput,
+        type MutationOptions,
+        type TagInput,
+} from "@/contexts/data";
+import { supabaseRequest } from "@/lib/supabase-client";
+import type {
+        TEntryRow,
+        TExclusionRow,
+        TGroupRow,
+        TPopulatedEntry,
+        TRecurringConfigRow,
+        TTagRow,
+} from "@/evolu-queries";
+
+import type { ReactNode } from "react";
+
+const TABLES = {
+        entry: "entry",
+        entryGroup: "entry_group",
+        entryTag: "entry_tag",
+        recurringConfig: "recurring_config",
+        exclusion: "exclusion",
+} as const;
+
+type RawGroupRow = {
+        id: string;
+        name: string | null;
+        icon: string | null;
+        is_deleted: boolean | null;
+};
+
+type RawTagRow = {
+        id: string;
+        name: string | null;
+        color: string | null;
+        suggest_id: string | null;
+        is_deleted: boolean | null;
+};
+
+type RawEntryRow = {
+        id: string;
+        name: string | null;
+        type: string | null;
+        currency_code: string | null;
+        amount: string | null;
+        date: string | null;
+        created_at: string;
+        updated_at: string | null;
+        fullfilled: boolean | null;
+        recurring_id: string | null;
+        group_id: string | null;
+        tag_id: string | null;
+        is_deleted: boolean | null;
+};
+
+type RawRecurringConfigRow = {
+        id: string;
+        frequency: string | null;
+        interval: number | null;
+        every: number | null;
+        start_date: string | null;
+        end_date: string | null;
+        created_at: string;
+        is_deleted: boolean | null;
+};
+
+type RawExclusionRow = {
+        id: string;
+        recurring_id: string;
+        modified_entry_id: string | null;
+        date: string;
+        reason: string;
+        created_at: string;
+        is_deleted: boolean | null;
+};
+
+const sanitizePayload = (payload: Record<string, unknown>) =>
+        JSON.parse(JSON.stringify(payload)) as Record<string, unknown>;
+
+const shouldRefresh = (options?: MutationOptions) => options?.skipRefresh !== true;
+
+const mapGroupRow = (row: RawGroupRow): TGroupRow | null => {
+        if (!row.name || row.is_deleted) return null;
+        return {
+                id: row.id,
+                name: row.name,
+                icon: row.icon,
+        };
+};
+
+const mapTagRow = (row: RawTagRow): TTagRow | null => {
+        if (!row.name || row.is_deleted) return null;
+        return {
+                id: row.id,
+                name: row.name,
+                color: row.color,
+                suggestId: row.suggest_id,
+        };
+};
+
+const mapEntryRow = (
+        row: RawEntryRow,
+        groupsMap: Map<string, TGroupRow>,
+        tagsMap: Map<string, TTagRow>,
+): TEntryRow | null => {
+        if (!row.name || !row.type || !row.amount || !row.currency_code || !row.date || row.is_deleted) {
+                return null;
+        }
+
+        const group = row.group_id ? groupsMap.get(row.group_id) : null;
+        const tag = row.tag_id ? tagsMap.get(row.tag_id) : null;
+
+        return {
+                entryId: row.id,
+                name: row.name,
+                type: row.type as TEntryRow["type"],
+                currencyCode: row.currency_code,
+                amount: row.amount,
+                date: row.date,
+                createdAt: row.created_at,
+                fullfilled: !!row.fullfilled,
+                recurringId: row.recurring_id,
+                updatedAt: row.updated_at,
+                groupId: row.group_id,
+                tagId: row.tag_id,
+                entryGroup: group ? { groupId: group.id, name: group.name } : null,
+                entryTag: tag ? { tagId: tag.id, name: tag.name, color: tag.color } : null,
+        };
+};
+
+const mapExclusionRow = (
+        row: RawExclusionRow,
+        entriesById: Map<string, TEntryRow>,
+): TExclusionRow | null => {
+        if (row.is_deleted) return null;
+        const reason = row.reason === "modification" ? "modification" : "deletion";
+        return {
+                exclusionId: row.id,
+                recurringId: row.recurring_id,
+                modifiedEntryId: row.modified_entry_id,
+                date: row.date,
+                reason,
+                createdAt: row.created_at,
+                modifiedEntry: row.modified_entry_id ? entriesById.get(row.modified_entry_id) ?? null : null,
+        };
+};
+
+const fetchGroups = async (): Promise<TGroupRow[]> => {
+        const { data, error } = await supabaseRequest<RawGroupRow[]>(`${TABLES.entryGroup}?select=*&order=created_at.asc`);
+        if (error) {
+                console.error("Failed to fetch groups", error);
+                return [];
+        }
+
+        return (data ?? []).map(mapGroupRow).filter((group): group is TGroupRow => !!group);
+};
+
+const fetchTags = async (): Promise<TTagRow[]> => {
+        const { data, error } = await supabaseRequest<RawTagRow[]>(`${TABLES.entryTag}?select=*&order=created_at.asc`);
+        if (error) {
+                console.error("Failed to fetch tags", error);
+                return [];
+        }
+
+        return (data ?? []).map(mapTagRow).filter((tag): tag is TTagRow => !!tag);
+};
+
+const fetchEntries = async (
+        groupsMap: Map<string, TGroupRow>,
+        tagsMap: Map<string, TTagRow>,
+): Promise<TEntryRow[]> => {
+        const { data, error } = await supabaseRequest<RawEntryRow[]>(
+                `${TABLES.entry}?select=*&recurring_id=is.null&order=date.asc`,
+        );
+
+        if (error) {
+                console.error("Failed to fetch entries", error);
+                return [];
+        }
+
+        return (data ?? [])
+                .map((row) => mapEntryRow(row as RawEntryRow, groupsMap, tagsMap))
+                .filter((entry): entry is TEntryRow => !!entry);
+};
+
+const fetchRecurringConfigs = async (
+        groupsMap: Map<string, TGroupRow>,
+        tagsMap: Map<string, TTagRow>,
+): Promise<TRecurringConfigRow[]> => {
+        const { data, error } = await supabaseRequest<RawRecurringConfigRow[]>(
+                `${TABLES.recurringConfig}?select=*&order=created_at.asc`,
+        );
+
+        if (error) {
+                console.error("Failed to fetch recurring configs", error);
+                return [];
+        }
+
+        const configs = (data ?? []).filter((row: RawRecurringConfigRow) => !row.is_deleted);
+        if (configs.length === 0) return [];
+
+        const configIds = configs.map((row) => row.id);
+
+        const inQuery = configIds.map((id) => `"${id}"`).join(",");
+        const { data: recurringEntriesData, error: recurringEntriesError } = await supabaseRequest<RawEntryRow[]>(
+                `${TABLES.entry}?select=*&recurring_id=in.(${inQuery})`,
+        );
+
+        if (recurringEntriesError) {
+                console.error("Failed to fetch recurring entries", recurringEntriesError);
+                return [];
+        }
+
+        const recurringEntries = (recurringEntriesData ?? [])
+                .map((row) => mapEntryRow(row as RawEntryRow, groupsMap, tagsMap))
+                .filter((entry): entry is TEntryRow => !!entry);
+
+        const entriesById = new Map<string, TEntryRow>();
+        recurringEntries.forEach((entry) => {
+                entriesById.set(entry.entryId, entry);
+        });
+
+        const { data: exclusionsData, error: exclusionsError } = await supabaseRequest<RawExclusionRow[]>(
+                `${TABLES.exclusion}?select=*&recurring_id=in.(${inQuery})`,
+        );
+
+        if (exclusionsError) {
+                console.error("Failed to fetch exclusions", exclusionsError);
+                return [];
+        }
+
+        const exclusions = (exclusionsData ?? [])
+                .map((row) => mapExclusionRow(row as RawExclusionRow, entriesById))
+                .filter((exclusion): exclusion is TExclusionRow => !!exclusion);
+
+        return configs.map((config: RawRecurringConfigRow) => {
+                const relatedEntries = recurringEntries
+                        .filter((entry) => entry.recurringId === config.id)
+                        .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+
+                const entry = relatedEntries[0] ?? null;
+
+                const relatedExclusions = exclusions.filter((exclusion) => exclusion.recurringId === config.id);
+
+                return {
+                        recurringConfigId: config.id,
+                        frequency: (config.frequency as TRecurringConfigRow["frequency"]) ?? "month",
+                        interval: config.interval ?? 0,
+                        every: config.every ?? 1,
+                        startDate: config.start_date ?? new Date().toISOString(),
+                        endDate: config.end_date,
+                        createdAt: config.created_at,
+                        entry,
+                        exclusions: relatedExclusions,
+                };
+        });
+};
+
+export const DataProvider = ({ children }: { children: ReactNode }) => {
+        const [loading, setLoading] = useState(true);
+        const [groups, setGroups] = useState<TGroupRow[]>([]);
+        const [tags, setTags] = useState<TTagRow[]>([]);
+        const [entries, setEntries] = useState<TEntryRow[]>([]);
+        const [recurringConfigs, setRecurringConfigs] = useState<TRecurringConfigRow[]>([]);
+
+        const refresh = useCallback(async () => {
+                setLoading(true);
+                try {
+                        const fetchedGroups = await fetchGroups();
+                        const groupsMap = new Map(fetchedGroups.map((group) => [group.id, group]));
+
+                        const fetchedTags = await fetchTags();
+                        const tagsMap = new Map(fetchedTags.map((tag) => [tag.id, tag]));
+
+                        const fetchedEntries = await fetchEntries(groupsMap, tagsMap);
+                        const fetchedRecurringConfigs = await fetchRecurringConfigs(groupsMap, tagsMap);
+
+                        setGroups(fetchedGroups);
+                        setTags(fetchedTags);
+                        setEntries(fetchedEntries);
+                        setRecurringConfigs(fetchedRecurringConfigs);
+                } catch (error) {
+                        console.error("Failed to refresh data", error);
+                } finally {
+                        setLoading(false);
+                }
+        }, []);
+
+        useEffect(() => {
+                void refresh();
+        }, [refresh]);
+
+        const withRefresh = useCallback(
+                async (operation: () => Promise<void>) => {
+                        await operation();
+                        await refresh();
+                },
+                [refresh],
+        );
+
+        const createGroup = useCallback(
+                async (name: string) => {
+                        await withRefresh(async () => {
+                                const { error } = await supabaseRequest(`${TABLES.entryGroup}`, {
+                                        method: "POST",
+                                        body: JSON.stringify({ name }),
+                                });
+                                if (error) throw error;
+                        });
+                },
+                [withRefresh],
+        );
+
+        const deleteGroup = useCallback(
+                async (id: string) => {
+                        await withRefresh(async () => {
+                                const { error } = await supabaseRequest(`${TABLES.entryGroup}?id=eq.${id}`, {
+                                        method: "PATCH",
+                                        body: JSON.stringify({ is_deleted: true }),
+                                });
+                                if (error) throw error;
+                        });
+                },
+                [withRefresh],
+        );
+
+        const createTag = useCallback(
+                async (input: TagInput) => {
+                        await withRefresh(async () => {
+                                const { error } = await supabaseRequest(`${TABLES.entryTag}`, {
+                                        method: "POST",
+                                        body: JSON.stringify({
+                                                name: input.name,
+                                                color: input.color,
+                                                suggest_id: input.suggestId,
+                                        }),
+                                });
+                                if (error) throw error;
+                        });
+                },
+                [withRefresh],
+        );
+
+        const updateTagColor = useCallback(
+                async (id: string, color: string | null) => {
+                        await withRefresh(async () => {
+                                const { error } = await supabaseRequest(`${TABLES.entryTag}?id=eq.${id}`, {
+                                        method: "PATCH",
+                                        body: JSON.stringify({ color }),
+                                });
+                                if (error) throw error;
+                        });
+                },
+                [withRefresh],
+        );
+
+        const deleteTag = useCallback(
+                async (id: string) => {
+                        await withRefresh(async () => {
+                                const { error } = await supabaseRequest(`${TABLES.entryTag}?id=eq.${id}`, {
+                                        method: "PATCH",
+                                        body: JSON.stringify({ is_deleted: true }),
+                                });
+                                if (error) throw error;
+                        });
+                },
+                [withRefresh],
+        );
+
+        const createEntry = useCallback(
+                async (input: CreateEntryInput, options?: MutationOptions) => {
+                        const { data, error } = await supabaseRequest<{ id: string }[]>(`${TABLES.entry}`, {
+                                method: "POST",
+                                body: JSON.stringify({
+                                        name: input.name,
+                                        amount: input.amount,
+                                        currency_code: input.currencyCode,
+                                        date: input.date,
+                                        type: input.type,
+                                        group_id: input.groupId,
+                                        tag_id: input.tagId,
+                                        fullfilled: input.fullfilled,
+                                        recurring_id: input.recurringId,
+                                }),
+                                headers: { Prefer: "return=representation" },
+                        });
+
+                        if (error) {
+                                console.error("Failed to create entry", error);
+                                return null;
+                        }
+
+                        if (shouldRefresh(options)) {
+                                await refresh();
+                        }
+                        return data?.[0]?.id ?? null;
+                },
+                [refresh],
+        );
+
+        const createRecurringConfig = useCallback(
+                async (input: CreateRecurringConfigInput, options?: MutationOptions) => {
+                        const { data, error } = await supabaseRequest<{ id: string }[]>(`${TABLES.recurringConfig}`, {
+                                method: "POST",
+                                body: JSON.stringify({
+                                        frequency: input.frequency,
+                                        interval: input.interval,
+                                        every: input.every,
+                                        start_date: input.startDate,
+                                        end_date: input.endDate,
+                                }),
+                                headers: { Prefer: "return=representation" },
+                        });
+
+                        if (error) {
+                                console.error("Failed to create recurring config", error);
+                                return null;
+                        }
+
+                        if (shouldRefresh(options)) {
+                                await refresh();
+                        }
+                        return data?.[0]?.id ?? null;
+                },
+                [refresh],
+        );
+
+        const createExclusion = useCallback(
+                async (input: {
+                        recurringId: string;
+                        date: string;
+                        reason: "deletion" | "modification";
+                        modifiedEntryId: string | null;
+                }, options?: MutationOptions) => {
+                        const { data, error } = await supabaseRequest<{ id: string }[]>(`${TABLES.exclusion}`, {
+                                method: "POST",
+                                body: JSON.stringify({
+                                        recurring_id: input.recurringId,
+                                        date: input.date,
+                                        reason: input.reason,
+                                        modified_entry_id: input.modifiedEntryId,
+                                }),
+                                headers: { Prefer: "return=representation" },
+                        });
+
+                        if (error) {
+                                console.error("Failed to create exclusion", error);
+                                return null;
+                        }
+
+                        if (shouldRefresh(options)) {
+                                await refresh();
+                        }
+                        return data?.[0]?.id ?? null;
+                },
+                [refresh],
+        );
+
+        const updateEntry = useCallback(
+                async (
+                        id: string,
+                        values: Partial<Omit<CreateEntryInput, "recurringId" | "date"> & { date?: string; recurringId?: string | null }>,
+                        options?: MutationOptions,
+                ) => {
+                        const payload = sanitizePayload({
+                                name: values.name,
+                                amount: values.amount,
+                                currency_code: values.currencyCode,
+                                date: values.date,
+                                type: values.type,
+                                group_id: values.groupId,
+                                tag_id: values.tagId,
+                                fullfilled: values.fullfilled,
+                                recurring_id: values.recurringId,
+                        });
+
+                        const { error } = await supabaseRequest(`${TABLES.entry}?id=eq.${id}`, {
+                                method: "PATCH",
+                                body: JSON.stringify(payload),
+                        });
+
+                        if (error) {
+                                console.error("Failed to update entry", error);
+                                return;
+                        }
+
+                        if (shouldRefresh(options)) {
+                                await refresh();
+                        }
+                },
+                [refresh],
+        );
+
+        const updateRecurringConfig = useCallback(
+                async (
+                        id: string,
+                        values: Partial<{
+                                interval: number | null;
+                                every: number | null;
+                                endDate: string | null;
+                                isDeleted: boolean;
+                        }>,
+                        options?: MutationOptions,
+                ) => {
+                        const payload = sanitizePayload({
+                                interval: values.interval ?? undefined,
+                                every: values.every ?? undefined,
+                                end_date: values.endDate ?? undefined,
+                                is_deleted: values.isDeleted ?? undefined,
+                        });
+
+                        const { error } = await supabaseRequest(`${TABLES.recurringConfig}?id=eq.${id}`, {
+                                method: "PATCH",
+                                body: JSON.stringify(payload),
+                        });
+
+                        if (error) {
+                                console.error("Failed to update recurring config", error);
+                                return;
+                        }
+
+                        if (shouldRefresh(options)) {
+                                await refresh();
+                        }
+                },
+                [refresh],
+        );
+
+        const updateExclusion = useCallback(
+                async (
+                        id: string,
+                        values: Partial<{ reason: "deletion" | "modification" | null; isDeleted: boolean }>,
+                        options?: MutationOptions,
+                ) => {
+                        const payload = sanitizePayload({
+                                reason: values.reason ?? undefined,
+                                is_deleted: values.isDeleted ?? undefined,
+                        });
+
+                        const { error } = await supabaseRequest(`${TABLES.exclusion}?id=eq.${id}`, {
+                                method: "PATCH",
+                                body: JSON.stringify(payload),
+                        });
+
+                        if (error) {
+                                console.error("Failed to update exclusion", error);
+                                return;
+                        }
+
+                        if (shouldRefresh(options)) {
+                                await refresh();
+                        }
+                },
+                [refresh],
+        );
+
+        const toggleEntryFullfilled = useCallback(
+                async (entry: TPopulatedEntry) => {
+                        if (entry.exclusionId && entry.details.entryId) {
+                                await updateEntry(
+                                        entry.details.entryId,
+                                        {
+                                                fullfilled: !entry.details.fullfilled,
+                                        },
+                                        { skipRefresh: true },
+                                );
+                                await refresh();
+                                return;
+                        }
+
+                        if (entry.id && !entry.recurringConfigId) {
+                                await updateEntry(
+                                        entry.id,
+                                        {
+                                                fullfilled: !entry.details.fullfilled,
+                                        },
+                                        { skipRefresh: true },
+                                );
+                                await refresh();
+                                return;
+                        }
+
+                        if (entry.recurringConfigId) {
+                                const newEntryId = await createEntry(
+                                        {
+                                                name: entry.details.name,
+                                                amount: entry.details.amount,
+                                                currencyCode: entry.details.currencyCode,
+                                                date: entry.date.toISOString(),
+                                                type: entry.details.type,
+                                                groupId: entry.details.groupId,
+                                                tagId: entry.details.tagId,
+                                                fullfilled: !entry.details.fullfilled,
+                                                recurringId: entry.recurringConfigId,
+                                        },
+                                        { skipRefresh: true },
+                                );
+
+                                if (newEntryId) {
+                                        await createExclusion(
+                                                {
+                                                        recurringId: entry.recurringConfigId,
+                                                        date: entry.date.toISOString(),
+                                                        reason: "modification",
+                                                        modifiedEntryId: newEntryId,
+                                                },
+                                                { skipRefresh: true },
+                                        );
+                                }
+
+                                await refresh();
+                        }
+                },
+                [createEntry, createExclusion, refresh, updateEntry],
+        );
+
+        const deleteEntry = useCallback(
+                async (entry: TPopulatedEntry, withSubsequents = false) => {
+                        if (entry.exclusionId) {
+                                await supabaseRequest(`${TABLES.exclusion}?id=eq.${entry.exclusionId}`, {
+                                        method: "PATCH",
+                                        body: JSON.stringify({ reason: "deletion" }),
+                                });
+                        } else if (entry.id && !entry.recurringConfigId) {
+                                await supabaseRequest(`${TABLES.entry}?id=eq.${entry.id}`, {
+                                        method: "PATCH",
+                                        body: JSON.stringify({ is_deleted: true }),
+                                });
+                        } else if (entry.recurringConfigId) {
+                                await supabaseRequest(`${TABLES.exclusion}`, {
+                                        method: "POST",
+                                        body: JSON.stringify({
+                                                recurring_id: entry.recurringConfigId,
+                                                date: entry.date.toISOString(),
+                                                reason: "deletion",
+                                                modified_entry_id: null,
+                                        }),
+                                        headers: { Prefer: "return=representation" },
+                                });
+                        }
+
+                        if (withSubsequents && entry.recurringConfigId) {
+                                const { data: exclusionsData } = await supabaseRequest<RawExclusionRow[]>(
+                                        `${TABLES.exclusion}?select=*&recurring_id=eq.${entry.recurringConfigId}&is_deleted=is.false`,
+                                );
+
+                                const exclusions = (exclusionsData ?? []).map((row) => row as RawExclusionRow);
+
+                                if (entry.index <= 1) {
+                                        await supabaseRequest(`${TABLES.recurringConfig}?id=eq.${entry.recurringConfigId}`, {
+                                                method: "PATCH",
+                                                body: JSON.stringify({ is_deleted: true }),
+                                        });
+                                        await Promise.all(
+                                                exclusions.map(async (exclusion) => {
+                                                        await supabaseRequest(`${TABLES.exclusion}?id=eq.${exclusion.id}`, {
+                                                                method: "PATCH",
+                                                                body: JSON.stringify({ is_deleted: true }),
+                                                        });
+                                                }),
+                                        );
+                                } else {
+                                        const entryDate = entry.date.getTime();
+                                        await Promise.all(
+                                                exclusions
+                                                        .filter((exclusion) => new Date(exclusion.date).getTime() > entryDate)
+                                                        .map(async (exclusion) => {
+                                                                await supabaseRequest(`${TABLES.exclusion}?id=eq.${exclusion.id}`, {
+                                                                        method: "PATCH",
+                                                                        body: JSON.stringify({ is_deleted: true }),
+                                                                });
+                                                        }),
+                                        );
+
+                                        await supabaseRequest(`${TABLES.recurringConfig}?id=eq.${entry.recurringConfigId}`, {
+                                                method: "PATCH",
+                                                body: JSON.stringify({
+                                                        end_date: entry.date.toISOString(),
+                                                        interval: entry.index - 1,
+                                                }),
+                                        });
+                                }
+                        }
+
+                        await refresh();
+                },
+                [refresh],
+        );
+
+        const editEntry = useCallback(
+                async ({
+                        entry,
+                        newName,
+                        newAmount,
+                        newGroup,
+                        newTag,
+                        applyToSubsequents = false,
+                        onComplete,
+                }: EditEntryInput) => {
+                        if (!newName || !newAmount) return;
+
+                        const values = {
+                                name: newName,
+                                amount: newAmount,
+                                groupId: newGroup,
+                                tagId: newTag,
+                        } as const;
+
+                        if (entry.exclusionId && entry.details.entryId) {
+                                await updateEntry(entry.details.entryId, values, { skipRefresh: true });
+                        } else if (entry.id && !entry.recurringConfigId) {
+                                await updateEntry(entry.id, values, { skipRefresh: true });
+                        } else if (entry.recurringConfigId && !entry.exclusionId) {
+                                const newEntryId = await createEntry(
+                                        {
+                                                name: entry.details.name,
+                                                amount: values.amount,
+                                                currencyCode: entry.details.currencyCode,
+                                                date: entry.date.toISOString(),
+                                                type: entry.details.type,
+                                                groupId: values.groupId,
+                                                tagId: values.tagId,
+                                                fullfilled: false,
+                                                recurringId: entry.recurringConfigId,
+                                        },
+                                        { skipRefresh: true },
+                                );
+
+                                if (newEntryId) {
+                                        await createExclusion(
+                                                {
+                                                        recurringId: entry.recurringConfigId,
+                                                        date: entry.date.toISOString(),
+                                                        reason: "modification",
+                                                        modifiedEntryId: newEntryId,
+                                                },
+                                                { skipRefresh: true },
+                                        );
+                                }
+                        }
+
+                        if (applyToSubsequents && entry.recurringConfigId && entry.config) {
+                                const { data: exclusionsData, error: exclusionsError } =
+                                        await supabaseRequest<RawExclusionRow[]>(
+                                                `${TABLES.exclusion}?select=*&recurring_id=eq.${entry.recurringConfigId}&is_deleted=is.false`,
+                                        );
+
+                                if (exclusionsError) {
+                                        console.error("Failed to fetch exclusions for edit", exclusionsError);
+                                }
+
+                                const exclusions = (exclusionsData ?? []).map((row) => row as RawExclusionRow);
+
+                                await Promise.all(
+                                        exclusions
+                                                .filter((exclusion) => new Date(exclusion.date).getTime() > entry.date.getTime())
+                                                .map(async (exclusion) => {
+                                                        const { error } = await supabaseRequest(
+                                                                `${TABLES.exclusion}?id=eq.${exclusion.id}`,
+                                                                {
+                                                                        method: "PATCH",
+                                                                        body: JSON.stringify({ reason: "deletion" }),
+                                                                },
+                                                        );
+
+                                                        if (error) {
+                                                                console.error(`Failed to update exclusion ${exclusion.id}`, error);
+                                                        }
+                                                }),
+                                );
+
+                                await createExclusion(
+                                        {
+                                                recurringId: entry.recurringConfigId,
+                                                date: entry.date.toISOString(),
+                                                reason: "deletion",
+                                                modifiedEntryId: null,
+                                        },
+                                        { skipRefresh: true },
+                                );
+
+                                await updateRecurringConfig(
+                                        entry.recurringConfigId,
+                                        {
+                                                endDate: entry.date.toISOString(),
+                                                interval: entry.index - 1,
+                                                every: entry.config.every || 1,
+                                        },
+                                        { skipRefresh: true },
+                                );
+
+                                const newRecurringId = await createRecurringConfig(
+                                        {
+                                                frequency: entry.config.frequency,
+                                                interval: entry.config.interval ? entry.config.interval - entry.index + 1 : 0,
+                                                every: entry.config.every || 1,
+                                                startDate: entry.date.toISOString(),
+                                                endDate: entry.config.endDate,
+                                        },
+                                        { skipRefresh: true },
+                                );
+
+                                if (newRecurringId) {
+                                        const newEntryId = await createEntry(
+                                                {
+                                                        name: values.name,
+                                                        amount: values.amount,
+                                                        currencyCode: entry.details.currencyCode,
+                                                        date: entry.date.toISOString(),
+                                                        type: entry.details.type,
+                                                        groupId: values.groupId,
+                                                        tagId: values.tagId,
+                                                        fullfilled: !!entry.details.fullfilled,
+                                                        recurringId: newRecurringId,
+                                                },
+                                                { skipRefresh: true },
+                                        );
+
+                                        if (newEntryId) {
+                                                await createExclusion(
+                                                        {
+                                                                recurringId: newRecurringId,
+                                                                date: entry.date.toISOString(),
+                                                                reason: "modification",
+                                                                modifiedEntryId: newEntryId,
+                                                        },
+                                                        { skipRefresh: true },
+                                                );
+                                        }
+                                }
+                        }
+
+                        await refresh();
+                        onComplete?.();
+                },
+                [createEntry, createExclusion, createRecurringConfig, refresh, updateEntry, updateRecurringConfig],
+        );
+
+        const eraseAllData = useCallback(async () => {
+                const tables = [
+                        TABLES.exclusion,
+                        TABLES.entry,
+                        TABLES.recurringConfig,
+                        TABLES.entryGroup,
+                        TABLES.entryTag,
+                ];
+
+                for (const table of tables) {
+                        const { error } = await supabaseRequest(`${table}?id=neq.00000000-0000-0000-0000-000000000000`, {
+                                method: "DELETE",
+                        });
+                        if (error) {
+                                console.error(`Failed to erase data from ${table}`, error);
+                        }
+                }
+
+                await refresh();
+        }, [refresh]);
+
+        const value: DataContextValue = {
+                loading,
+                groups,
+                tags,
+                entries,
+                recurringConfigs,
+                refresh,
+                createGroup,
+                deleteGroup,
+                createTag,
+                updateTagColor,
+                deleteTag,
+                createEntry,
+                createRecurringConfig,
+                createExclusion,
+                updateEntry,
+                updateRecurringConfig,
+                updateExclusion,
+                toggleEntryFullfilled,
+                deleteEntry,
+                editEntry,
+                eraseAllData,
+        };
+
+        return <DataContext.Provider value={value}>{children}</DataContext.Provider>;
+};

--- a/src/providers/screens.tsx
+++ b/src/providers/screens.tsx
@@ -1,18 +1,11 @@
 import { ScreensContext } from "@/contexts/screens";
+import { useEntries, useRecurringConfigs } from "@/contexts/data";
 import type { TGroupId, TTagId } from "@/evolu-db";
-import {
-	type TCALCULATIONS_OUTPUT_V2,
-	type TPopulatedEntry,
-	entriesQuery,
-	getCalculations_v2,
-	populateEntries,
-	recurringConfigsQuery,
-} from "@/evolu-queries";
+import { type TCALCULATIONS_OUTPUT_V2, type TPopulatedEntry, getCalculations_v2, populateEntries } from "@/evolu-queries";
 import { useFilters } from "@/hooks/use-filters";
 import { useLocalization } from "@/hooks/use-localization";
 import { requestRates, storageKeys } from "@/lib/utils";
 import type { TCalendarVision, TEntryType, TScreenId } from "@/types";
-import { useQuery } from "@evolu/react";
 import { useLocalStorage } from "@uidotdev/usehooks";
 import dayjs from "dayjs";
 import type React from "react";
@@ -41,12 +34,12 @@ export interface ScreensContextType {
 export const ScreensProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
 	// const [owner, setOwner] = useState(evolu.getOwner());
 	// const [error, setError] = useState(evolu.getError());
-	const recurringConfigs = useQuery(recurringConfigsQuery);
-	const entries = useQuery(entriesQuery);
-	const populatedEntries = useMemo(
-		() => populateEntries(entries.rows, recurringConfigs.rows),
-		[entries.rows, recurringConfigs.rows],
-	);
+        const recurringConfigs = useRecurringConfigs();
+        const entries = useEntries();
+        const populatedEntries = useMemo(
+                () => populateEntries(entries, recurringConfigs),
+                [entries, recurringConfigs],
+        );
 	// user can view 12 months into the past
 	const viewportStartDate = dayjs().startOf("month").subtract(12, "month");
 	// user can only view 12 months into the future

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,10 +7,10 @@ import { defineConfig } from "vite";
 import { VitePWA } from "vite-plugin-pwa";
 
 export default defineConfig({
-	optimizeDeps: {
-		exclude: ["@evolu/react", "@sqlite.org/sqlite-wasm"],
-		include: ["react-dom"],
-	},
+        optimizeDeps: {
+                exclude: ["@sqlite.org/sqlite-wasm"],
+                include: ["react-dom"],
+        },
 	worker: {
 		format: "es",
 	},


### PR DESCRIPTION
## Summary
- add mutation options and payload sanitization helpers to the data provider to control when refreshes occur
- finish migrating edit, toggle, and erase flows to the fetch-based Supabase helper with improved error handling
- remove the unused `@supabase/supabase-js` dependency now that the custom client handles requests

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cf10a836c88325b26d45138fe7d02f