### PR TITLE
Allow overriding Vite dev server port

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ VITE_SUPABASE_ANON_KEY=<your-supabase-anon-key>
 
 Restart the development server after updating these values.
 
+You can override the default development server port (`5171`) by setting the `PORT`
+environment variable when starting Vite:
+
+```bash
+PORT=5173 pnpm dev
+```
+
 ## Socials
 
 - **X:** Follow [@needim](https://x.com/needim) for the latest updates.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,11 @@ import Unfonts from "unplugin-fonts/vite";
 import { defineConfig } from "vite";
 import { VitePWA } from "vite-plugin-pwa";
 
+const DEFAULT_DEV_SERVER_PORT = 5171;
+const envPort = Number.parseInt(process.env.PORT ?? "", 10);
+const serverPort =
+        Number.isFinite(envPort) && envPort > 0 ? envPort : DEFAULT_DEV_SERVER_PORT;
+
 export default defineConfig({
         optimizeDeps: {
                 exclude: ["@sqlite.org/sqlite-wasm"],
@@ -17,10 +22,9 @@ export default defineConfig({
 	define: {
 		__APP_VERSION__: JSON.stringify(process.env.npm_package_version),
 	},
-	server: {
-		host: "0.0.0.0",
-		port: 5171,
-		strictPort: true,
+        server: {
+                host: "0.0.0.0",
+                port: serverPort,
 
 		...(process.env.NODE_ENV === "development" &&
 			fs.existsSync("./localhost-key.pem") &&


### PR DESCRIPTION
## Summary
- allow overriding the Vite dev server port via a `PORT` environment variable with a default of 5171
- relax the dev server configuration so Vite can fall back to the next available port
- document the new `PORT` option in the README

## Testing
- pnpm dev (with port 5171 already in use)


------
https://chatgpt.com/codex/tasks/task_e_68cf38583dcc832583ac257e82d612a3